### PR TITLE
Add diagonal grid types for composition guidance

### DIFF
--- a/src/main_window.py
+++ b/src/main_window.py
@@ -42,7 +42,21 @@ from .handlers.display import show_combined_image, show_single_channel_image, up
 from .handlers.image_saving import save_image_with_dialog
 from .handlers.keyboard import handle_key_press
 from .widgets.channel_controller import ChannelController
-from .widgets.grid_settings_dialog import GRID_TYPE_3X3, GRID_TYPE_GOLDEN_RATIO, GRID_TYPE_NONE, GridSettingsDialog
+from .widgets.grid_settings_dialog import (
+    GRID_TYPE_3X3,
+    GRID_TYPE_DIAGONAL_1_1,
+    GRID_TYPE_DIAGONAL_2_3,
+    GRID_TYPE_DIAGONAL_3_2,
+    GRID_TYPE_DIAGONAL_3_4,
+    GRID_TYPE_DIAGONAL_4_3,
+    GRID_TYPE_DIAGONAL_GOLDEN_H,
+    GRID_TYPE_DIAGONAL_GOLDEN_V,
+    GRID_TYPE_DIAGONAL_THIRDS_H,
+    GRID_TYPE_DIAGONAL_THIRDS_V,
+    GRID_TYPE_GOLDEN_RATIO,
+    GRID_TYPE_NONE,
+    GridSettingsDialog,
+)
 from .widgets.image_viewer import ImageViewer
 from .widgets.status_bar import StatusBarHandler
 
@@ -683,6 +697,59 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
             self.viewer.grid_overlay.set_enabled(True)
             self.viewer.grid_overlay.set_grid_type(grid_type)
             self.status_handler.set_message("Golden ratio grid overlay enabled", self.status_handler.SHORT_TIMEOUT)
+        elif grid_type == GRID_TYPE_DIAGONAL_1_1:
+            # Enable diagonal 1:1 grid overlay
+            self.viewer.grid_overlay.set_enabled(True)
+            self.viewer.grid_overlay.set_grid_type(grid_type)
+            self.status_handler.set_message("Diagonal 1:1 grid overlay enabled", self.status_handler.SHORT_TIMEOUT)
+        elif grid_type == GRID_TYPE_DIAGONAL_2_3:
+            # Enable diagonal 2:3 grid overlay
+            self.viewer.grid_overlay.set_enabled(True)
+            self.viewer.grid_overlay.set_grid_type(grid_type)
+            self.status_handler.set_message("Diagonal 2:3 grid overlay enabled", self.status_handler.SHORT_TIMEOUT)
+        elif grid_type == GRID_TYPE_DIAGONAL_3_2:
+            # Enable diagonal 3:2 grid overlay
+            self.viewer.grid_overlay.set_enabled(True)
+            self.viewer.grid_overlay.set_grid_type(grid_type)
+            self.status_handler.set_message("Diagonal 3:2 grid overlay enabled", self.status_handler.SHORT_TIMEOUT)
+        elif grid_type == GRID_TYPE_DIAGONAL_3_4:
+            # Enable diagonal 3:4 grid overlay
+            self.viewer.grid_overlay.set_enabled(True)
+            self.viewer.grid_overlay.set_grid_type(grid_type)
+            self.status_handler.set_message("Diagonal 3:4 grid overlay enabled", self.status_handler.SHORT_TIMEOUT)
+        elif grid_type == GRID_TYPE_DIAGONAL_4_3:
+            # Enable diagonal 4:3 grid overlay
+            self.viewer.grid_overlay.set_enabled(True)
+            self.viewer.grid_overlay.set_grid_type(grid_type)
+            self.status_handler.set_message("Diagonal 4:3 grid overlay enabled", self.status_handler.SHORT_TIMEOUT)
+        elif grid_type == GRID_TYPE_DIAGONAL_THIRDS_V:
+            # Enable diagonal + thirds vertical grid overlay
+            self.viewer.grid_overlay.set_enabled(True)
+            self.viewer.grid_overlay.set_grid_type(grid_type)
+            self.status_handler.set_message(
+                "Diagonal + thirds V grid overlay enabled", self.status_handler.SHORT_TIMEOUT
+            )
+        elif grid_type == GRID_TYPE_DIAGONAL_THIRDS_H:
+            # Enable diagonal + thirds horizontal grid overlay
+            self.viewer.grid_overlay.set_enabled(True)
+            self.viewer.grid_overlay.set_grid_type(grid_type)
+            self.status_handler.set_message(
+                "Diagonal + thirds H grid overlay enabled", self.status_handler.SHORT_TIMEOUT
+            )
+        elif grid_type == GRID_TYPE_DIAGONAL_GOLDEN_V:
+            # Enable diagonal + golden vertical grid overlay
+            self.viewer.grid_overlay.set_enabled(True)
+            self.viewer.grid_overlay.set_grid_type(grid_type)
+            self.status_handler.set_message(
+                "Diagonal + golden V grid overlay enabled", self.status_handler.SHORT_TIMEOUT
+            )
+        elif grid_type == GRID_TYPE_DIAGONAL_GOLDEN_H:
+            # Enable diagonal + golden horizontal grid overlay
+            self.viewer.grid_overlay.set_enabled(True)
+            self.viewer.grid_overlay.set_grid_type(grid_type)
+            self.status_handler.set_message(
+                "Diagonal + golden H grid overlay enabled", self.status_handler.SHORT_TIMEOUT
+            )
 
         # Refresh the display
         self.viewer.viewport().update()

--- a/src/main_window.py
+++ b/src/main_window.py
@@ -42,7 +42,8 @@ from .handlers.display import show_combined_image, show_single_channel_image, up
 from .handlers.image_saving import save_image_with_dialog
 from .handlers.keyboard import handle_key_press
 from .widgets.channel_controller import ChannelController
-from .widgets.grid_settings_dialog import (
+from .widgets.grid_settings_dialog import GridSettingsDialog
+from .widgets.grid_types import (
     GRID_TYPE_3X3,
     GRID_TYPE_DIAGONAL_1_1,
     GRID_TYPE_DIAGONAL_2_3,
@@ -55,7 +56,6 @@ from .widgets.grid_settings_dialog import (
     GRID_TYPE_DIAGONAL_THIRDS_V,
     GRID_TYPE_GOLDEN_RATIO,
     GRID_TYPE_NONE,
-    GridSettingsDialog,
 )
 from .widgets.image_viewer import ImageViewer
 from .widgets.status_bar import StatusBarHandler
@@ -76,6 +76,20 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
             - handlers.display: Functions for updating the main display.
             - handlers.keyboard: Keyboard shortcut handling.
     """
+
+    GRID_TYPE_STATUS_MESSAGES = {
+        GRID_TYPE_3X3: "3x3 grid overlay enabled",
+        GRID_TYPE_GOLDEN_RATIO: "Golden ratio grid overlay enabled",
+        GRID_TYPE_DIAGONAL_1_1: "Diagonal 1:1 grid overlay enabled",
+        GRID_TYPE_DIAGONAL_2_3: "Diagonal 2:3 grid overlay enabled",
+        GRID_TYPE_DIAGONAL_3_2: "Diagonal 3:2 grid overlay enabled",
+        GRID_TYPE_DIAGONAL_3_4: "Diagonal 3:4 grid overlay enabled",
+        GRID_TYPE_DIAGONAL_4_3: "Diagonal 4:3 grid overlay enabled",
+        GRID_TYPE_DIAGONAL_THIRDS_V: "Diagonal + thirds V grid overlay enabled",
+        GRID_TYPE_DIAGONAL_THIRDS_H: "Diagonal + thirds H grid overlay enabled",
+        GRID_TYPE_DIAGONAL_GOLDEN_V: "Diagonal + golden V grid overlay enabled",
+        GRID_TYPE_DIAGONAL_GOLDEN_H: "Diagonal + golden H grid overlay enabled",
+    }
 
     def __init__(self) -> None:
         """
@@ -684,72 +698,25 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
             None
         """
         if grid_type == GRID_TYPE_NONE:
-            # Disable grid overlay
             self.viewer.grid_overlay.set_enabled(False)
             self.status_handler.set_message("Grid overlay disabled", self.status_handler.SHORT_TIMEOUT)
-        elif grid_type == GRID_TYPE_3X3:
-            # Enable 3x3 grid overlay
+        else:
+            message = self.GRID_TYPE_STATUS_MESSAGES.get(grid_type)
+            if message is None:
+                self.viewer.grid_overlay.set_enabled(False)
+                self.status_handler.set_message("Unsupported grid type selected", self.status_handler.SHORT_TIMEOUT)
+                self.viewer.viewport().update()
+                return
+
             self.viewer.grid_overlay.set_enabled(True)
-            self.viewer.grid_overlay.set_grid_type(grid_type)
-            self.status_handler.set_message("3x3 grid overlay enabled", self.status_handler.SHORT_TIMEOUT)
-        elif grid_type == GRID_TYPE_GOLDEN_RATIO:
-            # Enable golden ratio grid overlay
-            self.viewer.grid_overlay.set_enabled(True)
-            self.viewer.grid_overlay.set_grid_type(grid_type)
-            self.status_handler.set_message("Golden ratio grid overlay enabled", self.status_handler.SHORT_TIMEOUT)
-        elif grid_type == GRID_TYPE_DIAGONAL_1_1:
-            # Enable diagonal 1:1 grid overlay
-            self.viewer.grid_overlay.set_enabled(True)
-            self.viewer.grid_overlay.set_grid_type(grid_type)
-            self.status_handler.set_message("Diagonal 1:1 grid overlay enabled", self.status_handler.SHORT_TIMEOUT)
-        elif grid_type == GRID_TYPE_DIAGONAL_2_3:
-            # Enable diagonal 2:3 grid overlay
-            self.viewer.grid_overlay.set_enabled(True)
-            self.viewer.grid_overlay.set_grid_type(grid_type)
-            self.status_handler.set_message("Diagonal 2:3 grid overlay enabled", self.status_handler.SHORT_TIMEOUT)
-        elif grid_type == GRID_TYPE_DIAGONAL_3_2:
-            # Enable diagonal 3:2 grid overlay
-            self.viewer.grid_overlay.set_enabled(True)
-            self.viewer.grid_overlay.set_grid_type(grid_type)
-            self.status_handler.set_message("Diagonal 3:2 grid overlay enabled", self.status_handler.SHORT_TIMEOUT)
-        elif grid_type == GRID_TYPE_DIAGONAL_3_4:
-            # Enable diagonal 3:4 grid overlay
-            self.viewer.grid_overlay.set_enabled(True)
-            self.viewer.grid_overlay.set_grid_type(grid_type)
-            self.status_handler.set_message("Diagonal 3:4 grid overlay enabled", self.status_handler.SHORT_TIMEOUT)
-        elif grid_type == GRID_TYPE_DIAGONAL_4_3:
-            # Enable diagonal 4:3 grid overlay
-            self.viewer.grid_overlay.set_enabled(True)
-            self.viewer.grid_overlay.set_grid_type(grid_type)
-            self.status_handler.set_message("Diagonal 4:3 grid overlay enabled", self.status_handler.SHORT_TIMEOUT)
-        elif grid_type == GRID_TYPE_DIAGONAL_THIRDS_V:
-            # Enable diagonal + thirds vertical grid overlay
-            self.viewer.grid_overlay.set_enabled(True)
-            self.viewer.grid_overlay.set_grid_type(grid_type)
-            self.status_handler.set_message(
-                "Diagonal + thirds V grid overlay enabled", self.status_handler.SHORT_TIMEOUT
-            )
-        elif grid_type == GRID_TYPE_DIAGONAL_THIRDS_H:
-            # Enable diagonal + thirds horizontal grid overlay
-            self.viewer.grid_overlay.set_enabled(True)
-            self.viewer.grid_overlay.set_grid_type(grid_type)
-            self.status_handler.set_message(
-                "Diagonal + thirds H grid overlay enabled", self.status_handler.SHORT_TIMEOUT
-            )
-        elif grid_type == GRID_TYPE_DIAGONAL_GOLDEN_V:
-            # Enable diagonal + golden vertical grid overlay
-            self.viewer.grid_overlay.set_enabled(True)
-            self.viewer.grid_overlay.set_grid_type(grid_type)
-            self.status_handler.set_message(
-                "Diagonal + golden V grid overlay enabled", self.status_handler.SHORT_TIMEOUT
-            )
-        elif grid_type == GRID_TYPE_DIAGONAL_GOLDEN_H:
-            # Enable diagonal + golden horizontal grid overlay
-            self.viewer.grid_overlay.set_enabled(True)
-            self.viewer.grid_overlay.set_grid_type(grid_type)
-            self.status_handler.set_message(
-                "Diagonal + golden H grid overlay enabled", self.status_handler.SHORT_TIMEOUT
-            )
+            try:
+                self.viewer.grid_overlay.set_grid_type(grid_type)
+            except ValueError:
+                self.viewer.grid_overlay.set_enabled(False)
+                self.status_handler.set_message("Unsupported grid type selected", self.status_handler.SHORT_TIMEOUT)
+                self.viewer.viewport().update()
+                return
+            self.status_handler.set_message(message, self.status_handler.SHORT_TIMEOUT)
 
         # Refresh the display
         self.viewer.viewport().update()

--- a/src/widgets/grid_overlay.py
+++ b/src/widgets/grid_overlay.py
@@ -17,14 +17,29 @@
 
 """
 Grid overlay for image viewer.
-Provides various grid types for composition guidance, including rule-of-thirds (3x3)
-and golden ratio grids.
+Provides various grid types for composition guidance, including rule-of-thirds (3x3),
+golden ratio grids, and diagonal lines.
 """
 
-from typing import Union
+from typing import Callable, Dict, Union
 
-from PyQt5.QtCore import QRect, QRectF, Qt
+from PyQt5.QtCore import QLineF, QRect, QRectF, Qt
 from PyQt5.QtGui import QColor, QPainter, QPen
+
+# Import grid type constants from grid_settings_dialog to avoid duplication
+from src.widgets.grid_settings_dialog import (
+    GRID_TYPE_3X3,
+    GRID_TYPE_DIAGONAL_1_1,
+    GRID_TYPE_DIAGONAL_2_3,
+    GRID_TYPE_DIAGONAL_3_2,
+    GRID_TYPE_DIAGONAL_3_4,
+    GRID_TYPE_DIAGONAL_4_3,
+    GRID_TYPE_DIAGONAL_GOLDEN_H,
+    GRID_TYPE_DIAGONAL_GOLDEN_V,
+    GRID_TYPE_DIAGONAL_THIRDS_H,
+    GRID_TYPE_DIAGONAL_THIRDS_V,
+    GRID_TYPE_GOLDEN_RATIO,
+)
 
 
 class GridOverlay:
@@ -34,11 +49,16 @@ class GridOverlay:
     Supports multiple grid types:
     - 3x3: Divides the image into 9 equal parts (rule-of-thirds)
     - Golden Ratio: Uses the golden ratio (1:0.618:1) for grid lines
+    - Diagonal 1:1: Draws 45-degree lines from each corner
+    - Diagonal 2:3: Draws lines at arctan(2/3) degrees from each corner (2:3 aspect ratio)
+    - Diagonal 3:2: Draws lines at arctan(3/2) degrees from each corner (3:2 aspect ratio)
+    - Diagonal 3:4: Draws lines at 36.87 degrees from each corner (3:4 aspect ratio)
+    - Diagonal 4:3: Draws lines at 53.13 degrees from each corner (4:3 aspect ratio)
+    - Diagonal + Thirds V: Diagonals plus vertical lines to rule-of-thirds division points
+    - Diagonal + Thirds H: Diagonals plus horizontal lines to rule-of-thirds division points
+    - Diagonal + Golden V: Diagonals plus vertical lines to golden ratio division points
+    - Diagonal + Golden H: Diagonals plus horizontal lines to golden ratio division points
     """
-
-    # Grid type constants
-    GRID_TYPE_3X3 = "3x3"
-    GRID_TYPE_GOLDEN_RATIO = "golden_ratio"
 
     def __init__(self) -> None:
         """Initialize the grid overlay with default settings."""
@@ -47,7 +67,22 @@ class GridOverlay:
         self._line_width = 4
         self._line_style = Qt.PenStyle.SolidLine
         self._opacity = 128  # Semi-transparent (0-255)
-        self._grid_type = self.GRID_TYPE_3X3  # Default to 3x3 grid
+        self._grid_type = GRID_TYPE_3X3  # Default to 3x3 grid
+
+        # Mapping of grid types to their drawing methods
+        self._grid_drawing_methods: Dict[str, Callable[[QPainter, QRectF], None]] = {
+            GRID_TYPE_3X3: self._draw_3x3_grid,
+            GRID_TYPE_GOLDEN_RATIO: self._draw_golden_ratio_grid,
+            GRID_TYPE_DIAGONAL_1_1: self._draw_diagonal_1_1_grid,
+            GRID_TYPE_DIAGONAL_2_3: self._draw_diagonal_2_3_grid,
+            GRID_TYPE_DIAGONAL_3_2: self._draw_diagonal_3_2_grid,
+            GRID_TYPE_DIAGONAL_3_4: self._draw_diagonal_3_4_grid,
+            GRID_TYPE_DIAGONAL_4_3: self._draw_diagonal_4_3_grid,
+            GRID_TYPE_DIAGONAL_THIRDS_V: self._draw_diagonal_thirds_v_grid,
+            GRID_TYPE_DIAGONAL_THIRDS_H: self._draw_diagonal_thirds_h_grid,
+            GRID_TYPE_DIAGONAL_GOLDEN_V: self._draw_diagonal_golden_v_grid,
+            GRID_TYPE_DIAGONAL_GOLDEN_H: self._draw_diagonal_golden_h_grid,
+        }
 
     def set_enabled(self, enabled: bool) -> None:
         """
@@ -146,14 +181,142 @@ class GridOverlay:
         painter.setPen(pen)
         painter.setBrush(Qt.BrushStyle.NoBrush)
 
-        # Draw grid based on type
-        if self._grid_type == self.GRID_TYPE_3X3:
-            self._draw_3x3_grid(painter, rect)
-        elif self._grid_type == self.GRID_TYPE_GOLDEN_RATIO:
-            self._draw_golden_ratio_grid(painter, rect)
+        # Draw grid based on type using dictionary dispatch
+        draw_method = self._grid_drawing_methods.get(self._grid_type)
+        if draw_method:
+            draw_method(painter, rect)
 
         # Restore the painter state
         painter.restore()
+
+    def _draw_diagonal_thirds_v_grid(self, painter: QPainter, rect: QRectF) -> None:
+        """
+        Draw diagonals connecting corners, plus vertical lines from each corner to
+        rule-of-thirds division points.
+
+        Each corner has exactly 2 lines:
+        - One diagonal to opposite corner
+        - One vertical line to a thirds division point on top or bottom edge
+        """
+        left = rect.left()
+        top = rect.top()
+        right = rect.right()
+        bottom = rect.bottom()
+        width = rect.width()
+
+        # Rule-of-thirds points
+        third_x1 = left + width / 3.0
+        third_x2 = left + 2.0 * width / 3.0
+
+        # Top-left corner: diagonal to bottom-right + line to 1/3 point on bottom edge
+        painter.drawLine(QLineF(left, top, right, bottom))
+        painter.drawLine(QLineF(left, top, third_x1, bottom))
+
+        # Top-right corner: diagonal to bottom-left + line to bottom edge 2/3 point
+        painter.drawLine(QLineF(right, top, left, bottom))
+        painter.drawLine(QLineF(right, top, third_x2, bottom))
+
+        # Bottom-left corner: line to 1/3 point on top edge
+        painter.drawLine(QLineF(left, bottom, third_x1, top))
+
+        # Bottom-right corner: line to 2/3 point on top edge
+        painter.drawLine(QLineF(right, bottom, third_x2, top))
+
+    def _draw_diagonal_thirds_h_grid(self, painter: QPainter, rect: QRectF) -> None:
+        """
+        Draw diagonals connecting corners, plus horizontal lines from each corner to rule-of-thirds division points.
+
+        Each corner has exactly 2 lines:
+        - One diagonal to opposite corner
+        - One horizontal line to a thirds division point on left or right edge
+        """
+        left = rect.left()
+        top = rect.top()
+        right = rect.right()
+        bottom = rect.bottom()
+        height = rect.height()
+
+        # Rule-of-thirds points
+        third_y1 = top + height / 3.0
+        third_y2 = top + 2.0 * height / 3.0
+
+        # Top-left corner: diagonal to bottom-right + line to 1/3 point on right edge
+        painter.drawLine(QLineF(left, top, right, bottom))
+        painter.drawLine(QLineF(left, top, right, third_y1))
+
+        # Top-right corner: diagonal to bottom-left + line to 1/3 point on left edge
+        painter.drawLine(QLineF(right, top, left, bottom))
+        painter.drawLine(QLineF(right, top, left, third_y1))
+
+        # Bottom-left corner: line to 2/3 point on right edge
+        painter.drawLine(QLineF(left, bottom, right, third_y2))
+
+        # Bottom-right corner: line to 2/3 point on left edge
+        painter.drawLine(QLineF(right, bottom, left, third_y2))
+
+    def _draw_diagonal_golden_v_grid(self, painter: QPainter, rect: QRectF) -> None:
+        """
+        Draw diagonals connecting corners, plus vertical lines from each corner to golden ratio division points.
+
+        Each corner has exactly 2 lines:
+        - One diagonal to opposite corner
+        - One vertical line to a golden ratio division point on top or bottom edge
+        """
+        left = rect.left()
+        top = rect.top()
+        right = rect.right()
+        bottom = rect.bottom()
+        width = rect.width()
+
+        # Golden ratio points (0.382 and 0.618)
+        golden_x1 = left + width * 0.382
+        golden_x2 = left + width * 0.618
+
+        # Top-left corner: diagonal to bottom-right + line to golden point (0.382) on bottom edge
+        painter.drawLine(QLineF(left, top, right, bottom))
+        painter.drawLine(QLineF(left, top, golden_x1, bottom))
+
+        # Top-right corner: diagonal to bottom-left + line to bottom edge golden point (0.618)
+        painter.drawLine(QLineF(right, top, left, bottom))
+        painter.drawLine(QLineF(right, top, golden_x2, bottom))
+
+        # Bottom-left corner: line to golden point (0.382) on top edge
+        painter.drawLine(QLineF(left, bottom, golden_x1, top))
+
+        # Bottom-right corner: line to golden point (0.618) on top edge
+        painter.drawLine(QLineF(right, bottom, golden_x2, top))
+
+    def _draw_diagonal_golden_h_grid(self, painter: QPainter, rect: QRectF) -> None:
+        """
+        Draw diagonals connecting corners, plus horizontal lines from each corner to golden ratio division points.
+
+        Each corner has exactly 2 lines:
+        - One diagonal to opposite corner
+        - One horizontal line to a golden ratio division point on left or right edge
+        """
+        left = rect.left()
+        top = rect.top()
+        right = rect.right()
+        bottom = rect.bottom()
+        height = rect.height()
+
+        # Golden ratio points (0.382 and 0.618)
+        golden_y1 = top + height * 0.382
+        golden_y2 = top + height * 0.618
+
+        # Top-left corner: diagonal to bottom-right + line to golden point (0.382) on right edge
+        painter.drawLine(QLineF(left, top, right, bottom))
+        painter.drawLine(QLineF(left, top, right, golden_y1))
+
+        # Top-right corner: diagonal to bottom-left + line to golden point (0.382) on left edge
+        painter.drawLine(QLineF(right, top, left, bottom))
+        painter.drawLine(QLineF(right, top, left, golden_y1))
+
+        # Bottom-left corner: line to golden point (0.618) on right edge
+        painter.drawLine(QLineF(left, bottom, right, golden_y2))
+
+        # Bottom-right corner: line to golden point (0.618) on left edge
+        painter.drawLine(QLineF(right, bottom, left, golden_y2))
 
     def _draw_3x3_grid(self, painter: QPainter, rect: QRectF) -> None:
         """
@@ -222,3 +385,371 @@ class GridOverlay:
         # Draw the horizontal lines
         painter.drawLine(int(left), int(y1), int(left + width), int(y1))
         painter.drawLine(int(left), int(y2), int(left + width), int(y2))
+
+    def _draw_diagonal_1_1_grid(self, painter: QPainter, rect: QRectF) -> None:  # pylint: disable=too-many-locals
+        """
+        Draw diagonal lines at 45 degrees from each corner (1:1 aspect ratio).
+
+        Draws four diagonal lines:
+        - From top-left corner at 45 degrees
+        - From top-right corner at 135 degrees
+        - From bottom-left corner at -45 degrees (315 degrees)
+        - From bottom-right corner at -135 degrees (225 degrees)
+
+        Args:
+            painter: QPainter object to draw with.
+            rect: The rectangle area to draw the grid on.
+        """
+        left = rect.left()
+        top = rect.top()
+        right = rect.right()
+        bottom = rect.bottom()
+        width = rect.width()
+        height = rect.height()
+
+        # Diagonal from top-left corner (going down-right at 45°)
+        # This line goes until it hits either the right edge or bottom edge
+        if width <= height:
+            # Hits right edge first
+            end_x1 = right
+            end_y1 = top + width
+        else:
+            # Hits bottom edge first
+            end_x1 = left + height
+            end_y1 = bottom
+
+        line1 = QLineF(left, top, end_x1, end_y1)
+        painter.drawLine(line1)
+
+        # Diagonal from top-right corner (going down-left at 135°)
+        if width <= height:
+            # Hits left edge first
+            end_x2 = left
+            end_y2 = top + width
+        else:
+            # Hits bottom edge first
+            end_x2 = right - height
+            end_y2 = bottom
+
+        line2 = QLineF(right, top, end_x2, end_y2)
+        painter.drawLine(line2)
+
+        # Diagonal from bottom-left corner (going up-right at -45°/315°)
+        if width <= height:
+            # Hits right edge first
+            end_x3 = right
+            end_y3 = bottom - width
+        else:
+            # Hits top edge first
+            end_x3 = left + height
+            end_y3 = top
+
+        line3 = QLineF(left, bottom, end_x3, end_y3)
+        painter.drawLine(line3)
+
+        # Diagonal from bottom-right corner (going up-left at -135°/225°)
+        if width <= height:
+            # Hits left edge first
+            end_x4 = left
+            end_y4 = bottom - width
+        else:
+            # Hits top edge first
+            end_x4 = right - height
+            end_y4 = top
+
+        line4 = QLineF(right, bottom, end_x4, end_y4)
+        painter.drawLine(line4)
+
+    def _draw_diagonal_2_3_grid(self, painter: QPainter, rect: QRectF) -> None:  # pylint: disable=too-many-locals
+        """
+        Draw diagonal lines at arctan(2/3) degrees from each corner (2:3 aspect ratio).
+
+        The angle corresponds to arctan(2/3) ≈ 33.69°, creating lines with a 2:3 slope.
+        For every 3 units horizontally, we go 2 units vertically.
+
+        Args:
+            painter: QPainter object to draw with.
+            rect: The rectangle area to draw the grid on.
+        """
+        left = rect.left()
+        top = rect.top()
+        right = rect.right()
+        bottom = rect.bottom()
+        width = rect.width()
+        height = rect.height()
+
+        # For 2:3 ratio, for every 3 units horizontally, we go 2 units vertically
+        # slope = 2/3 ≈ 0.667
+
+        # Diagonal from top-left corner (going down-right at ~33.69°)
+        if width * 2 <= height * 3:
+            # Hits right edge first: dx = width, dy = width * 2/3
+            end_x1 = right
+            end_y1 = top + width * 2.0 / 3.0
+        else:
+            # Hits bottom edge first: dy = height, dx = height * 3/2
+            end_x1 = left + height * 3.0 / 2.0
+            end_y1 = bottom
+
+        line1 = QLineF(left, top, end_x1, end_y1)
+        painter.drawLine(line1)
+
+        # Diagonal from top-right corner (going down-left)
+        if width * 2 <= height * 3:
+            # Hits left edge first
+            end_x2 = left
+            end_y2 = top + width * 2.0 / 3.0
+        else:
+            # Hits bottom edge first
+            end_x2 = right - height * 3.0 / 2.0
+            end_y2 = bottom
+
+        line2 = QLineF(right, top, end_x2, end_y2)
+        painter.drawLine(line2)
+
+        # Diagonal from bottom-left corner (going up-right)
+        if width * 2 <= height * 3:
+            # Hits right edge first
+            end_x3 = right
+            end_y3 = bottom - width * 2.0 / 3.0
+        else:
+            # Hits top edge first
+            end_x3 = left + height * 3.0 / 2.0
+            end_y3 = top
+
+        line3 = QLineF(left, bottom, end_x3, end_y3)
+        painter.drawLine(line3)
+
+        # Diagonal from bottom-right corner (going up-left)
+        if width * 2 <= height * 3:
+            # Hits left edge first
+            end_x4 = left
+            end_y4 = bottom - width * 2.0 / 3.0
+        else:
+            # Hits top edge first
+            end_x4 = right - height * 3.0 / 2.0
+            end_y4 = top
+
+        line4 = QLineF(right, bottom, end_x4, end_y4)
+        painter.drawLine(line4)
+
+    def _draw_diagonal_3_2_grid(self, painter: QPainter, rect: QRectF) -> None:  # pylint: disable=too-many-locals
+        """
+        Draw diagonal lines at arctan(3/2) degrees from each corner (3:2 aspect ratio).
+
+        The angle corresponds to arctan(3/2) ≈ 56.31°, creating lines with a 3:2 slope.
+        For every 2 units horizontally, we go 3 units vertically.
+
+        Args:
+            painter: QPainter object to draw with.
+            rect: The rectangle area to draw the grid on.
+        """
+        left = rect.left()
+        top = rect.top()
+        right = rect.right()
+        bottom = rect.bottom()
+        width = rect.width()
+        height = rect.height()
+
+        # For 3:2 ratio, for every 2 units horizontally, we go 3 units vertically
+        # slope = 3/2 = 1.5
+
+        # Diagonal from top-left corner (going down-right at ~56.31°)
+        if width * 3 <= height * 2:
+            # Hits right edge first: dx = width, dy = width * 3/2
+            end_x1 = right
+            end_y1 = top + width * 3.0 / 2.0
+        else:
+            # Hits bottom edge first: dy = height, dx = height * 2/3
+            end_x1 = left + height * 2.0 / 3.0
+            end_y1 = bottom
+
+        line1 = QLineF(left, top, end_x1, end_y1)
+        painter.drawLine(line1)
+
+        # Diagonal from top-right corner (going down-left)
+        if width * 3 <= height * 2:
+            # Hits left edge first
+            end_x2 = left
+            end_y2 = top + width * 3.0 / 2.0
+        else:
+            # Hits bottom edge first
+            end_x2 = right - height * 2.0 / 3.0
+            end_y2 = bottom
+
+        line2 = QLineF(right, top, end_x2, end_y2)
+        painter.drawLine(line2)
+
+        # Diagonal from bottom-left corner (going up-right)
+        if width * 3 <= height * 2:
+            # Hits right edge first
+            end_x3 = right
+            end_y3 = bottom - width * 3.0 / 2.0
+        else:
+            # Hits top edge first
+            end_x3 = left + height * 2.0 / 3.0
+            end_y3 = top
+
+        line3 = QLineF(left, bottom, end_x3, end_y3)
+        painter.drawLine(line3)
+
+        # Diagonal from bottom-right corner (going up-left)
+        if width * 3 <= height * 2:
+            # Hits left edge first
+            end_x4 = left
+            end_y4 = bottom - width * 3.0 / 2.0
+        else:
+            # Hits top edge first
+            end_x4 = right - height * 2.0 / 3.0
+            end_y4 = top
+
+        line4 = QLineF(right, bottom, end_x4, end_y4)
+        painter.drawLine(line4)
+
+    def _draw_diagonal_3_4_grid(self, painter: QPainter, rect: QRectF) -> None:  # pylint: disable=too-many-locals
+        """
+        Draw diagonal lines at 36.87 degrees from each corner (3:4 aspect ratio).
+
+        The angle of 36.87° corresponds to arctan(3/4), creating lines with a 3:4 slope.
+        This is complementary to the 53.13° diagonal (4:3 ratio).
+
+        Args:
+            painter: QPainter object to draw with.
+            rect: The rectangle area to draw the grid on.
+        """
+        left = rect.left()
+        top = rect.top()
+        right = rect.right()
+        bottom = rect.bottom()
+        width = rect.width()
+        height = rect.height()
+
+        # For 3:4 ratio, for every 4 units horizontally, we go 3 units vertically
+        # slope = 3/4 = 0.75
+
+        # Diagonal from top-left corner (going down-right at 36.87°)
+        # dx/dy = 4/3, so dx = 4 * (dy/3)
+        if width * 3 <= height * 4:
+            # Hits right edge first: dx = width, dy = width * 3/4
+            end_x1 = right
+            end_y1 = top + width * 3.0 / 4.0
+        else:
+            # Hits bottom edge first: dy = height, dx = height * 4/3
+            end_x1 = left + height * 4.0 / 3.0
+            end_y1 = bottom
+
+        line1 = QLineF(left, top, end_x1, end_y1)
+        painter.drawLine(line1)
+
+        # Diagonal from top-right corner (going down-left at 143.13°)
+        if width * 3 <= height * 4:
+            # Hits left edge first
+            end_x2 = left
+            end_y2 = top + width * 3.0 / 4.0
+        else:
+            # Hits bottom edge first
+            end_x2 = right - height * 4.0 / 3.0
+            end_y2 = bottom
+
+        line2 = QLineF(right, top, end_x2, end_y2)
+        painter.drawLine(line2)
+
+        # Diagonal from bottom-left corner (going up-right at -36.87°/323.13°)
+        if width * 3 <= height * 4:
+            # Hits right edge first
+            end_x3 = right
+            end_y3 = bottom - width * 3.0 / 4.0
+        else:
+            # Hits top edge first
+            end_x3 = left + height * 4.0 / 3.0
+            end_y3 = top
+
+        line3 = QLineF(left, bottom, end_x3, end_y3)
+        painter.drawLine(line3)
+
+        # Diagonal from bottom-right corner (going up-left at -143.13°/216.87°)
+        if width * 3 <= height * 4:
+            # Hits left edge first
+            end_x4 = left
+            end_y4 = bottom - width * 3.0 / 4.0
+        else:
+            # Hits top edge first
+            end_x4 = right - height * 4.0 / 3.0
+            end_y4 = top
+
+        line4 = QLineF(right, bottom, end_x4, end_y4)
+        painter.drawLine(line4)
+
+    def _draw_diagonal_4_3_grid(self, painter: QPainter, rect: QRectF) -> None:  # pylint: disable=too-many-locals
+        """
+        Draw diagonal lines at 53.13 degrees from each corner (4:3 aspect ratio).
+
+        The angle of 53.13° corresponds to arctan(4/3), creating lines with a 4:3 slope.
+        This is complementary to the 36.87° diagonal (3:4 ratio).
+
+        Args:
+            painter: QPainter object to draw with.
+            rect: The rectangle area to draw the grid on.
+        """
+        left = rect.left()
+        top = rect.top()
+        right = rect.right()
+        bottom = rect.bottom()
+        width = rect.width()
+        height = rect.height()
+
+        # For 4:3 ratio, for every 3 units horizontally, we go 4 units vertically
+        # slope = 4/3 ≈ 1.333
+
+        # Diagonal from top-left corner (going down-right at 53.13°)
+        # dx/dy = 3/4, so dx = 3 * (dy/4)
+        if width * 4 <= height * 3:
+            # Hits right edge first: dx = width, dy = width * 4/3
+            end_x1 = right
+            end_y1 = top + width * 4.0 / 3.0
+        else:
+            # Hits bottom edge first: dy = height, dx = height * 3/4
+            end_x1 = left + height * 3.0 / 4.0
+            end_y1 = bottom
+
+        line1 = QLineF(left, top, end_x1, end_y1)
+        painter.drawLine(line1)
+
+        # Diagonal from top-right corner (going down-left at 126.87°)
+        if width * 4 <= height * 3:
+            # Hits left edge first
+            end_x2 = left
+            end_y2 = top + width * 4.0 / 3.0
+        else:
+            # Hits bottom edge first
+            end_x2 = right - height * 3.0 / 4.0
+            end_y2 = bottom
+
+        line2 = QLineF(right, top, end_x2, end_y2)
+        painter.drawLine(line2)
+
+        # Diagonal from bottom-left corner (going up-right at -53.13°/306.87°)
+        if width * 4 <= height * 3:
+            # Hits right edge first
+            end_x3 = right
+            end_y3 = bottom - width * 4.0 / 3.0
+        else:
+            # Hits top edge first
+            end_x3 = left + height * 3.0 / 4.0
+            end_y3 = top
+
+        line3 = QLineF(left, bottom, end_x3, end_y3)
+        painter.drawLine(line3)
+
+        # Diagonal from bottom-right corner (going up-left at -126.87°/233.13°)
+        if width * 4 <= height * 3:
+            # Hits left edge first
+            end_x4 = left
+            end_y4 = bottom - width * 4.0 / 3.0
+        else:
+            # Hits top edge first
+            end_x4 = right - height * 3.0 / 4.0
+            end_y4 = top
+
+        line4 = QLineF(right, bottom, end_x4, end_y4)
+        painter.drawLine(line4)

--- a/src/widgets/grid_overlay.py
+++ b/src/widgets/grid_overlay.py
@@ -26,8 +26,7 @@ from typing import Callable, Dict, Union
 from PyQt5.QtCore import QLineF, QRect, QRectF, Qt
 from PyQt5.QtGui import QColor, QPainter, QPen
 
-# Import grid type constants from grid_settings_dialog to avoid duplication
-from src.widgets.grid_settings_dialog import (
+from .grid_types import (
     GRID_TYPE_3X3,
     GRID_TYPE_DIAGONAL_1_1,
     GRID_TYPE_DIAGONAL_2_3,
@@ -145,6 +144,8 @@ class GridOverlay:
         Args:
             grid_type: The grid type to use (GRID_TYPE_3X3 or GRID_TYPE_GOLDEN_RATIO).
         """
+        if grid_type not in self._grid_drawing_methods:
+            raise ValueError(f"Unsupported grid type: {grid_type}")
         self._grid_type = grid_type
 
     def get_grid_type(self) -> str:
@@ -171,6 +172,10 @@ class GridOverlay:
         if isinstance(rect, QRect):
             rect = QRectF(rect)
 
+        # Nothing to draw for invalid or zero-area rectangles.
+        if rect.width() <= 0 or rect.height() <= 0:
+            return
+
         # Save the current painter state
         painter.save()
 
@@ -182,9 +187,8 @@ class GridOverlay:
         painter.setBrush(Qt.BrushStyle.NoBrush)
 
         # Draw grid based on type using dictionary dispatch
-        draw_method = self._grid_drawing_methods.get(self._grid_type)
-        if draw_method:
-            draw_method(painter, rect)
+        draw_method = self._grid_drawing_methods.get(self._grid_type, self._draw_3x3_grid)
+        draw_method(painter, rect)
 
         # Restore the painter state
         painter.restore()
@@ -471,67 +475,7 @@ class GridOverlay:
             painter: QPainter object to draw with.
             rect: The rectangle area to draw the grid on.
         """
-        left = rect.left()
-        top = rect.top()
-        right = rect.right()
-        bottom = rect.bottom()
-        width = rect.width()
-        height = rect.height()
-
-        # For 2:3 ratio, for every 3 units horizontally, we go 2 units vertically
-        # slope = 2/3 ≈ 0.667
-
-        # Diagonal from top-left corner (going down-right at ~33.69°)
-        if width * 2 <= height * 3:
-            # Hits right edge first: dx = width, dy = width * 2/3
-            end_x1 = right
-            end_y1 = top + width * 2.0 / 3.0
-        else:
-            # Hits bottom edge first: dy = height, dx = height * 3/2
-            end_x1 = left + height * 3.0 / 2.0
-            end_y1 = bottom
-
-        line1 = QLineF(left, top, end_x1, end_y1)
-        painter.drawLine(line1)
-
-        # Diagonal from top-right corner (going down-left)
-        if width * 2 <= height * 3:
-            # Hits left edge first
-            end_x2 = left
-            end_y2 = top + width * 2.0 / 3.0
-        else:
-            # Hits bottom edge first
-            end_x2 = right - height * 3.0 / 2.0
-            end_y2 = bottom
-
-        line2 = QLineF(right, top, end_x2, end_y2)
-        painter.drawLine(line2)
-
-        # Diagonal from bottom-left corner (going up-right)
-        if width * 2 <= height * 3:
-            # Hits right edge first
-            end_x3 = right
-            end_y3 = bottom - width * 2.0 / 3.0
-        else:
-            # Hits top edge first
-            end_x3 = left + height * 3.0 / 2.0
-            end_y3 = top
-
-        line3 = QLineF(left, bottom, end_x3, end_y3)
-        painter.drawLine(line3)
-
-        # Diagonal from bottom-right corner (going up-left)
-        if width * 2 <= height * 3:
-            # Hits left edge first
-            end_x4 = left
-            end_y4 = bottom - width * 2.0 / 3.0
-        else:
-            # Hits top edge first
-            end_x4 = right - height * 3.0 / 2.0
-            end_y4 = top
-
-        line4 = QLineF(right, bottom, end_x4, end_y4)
-        painter.drawLine(line4)
+        self._draw_diagonal_ratio_grid(painter, rect, vertical_ratio=2.0, horizontal_ratio=3.0)
 
     def _draw_diagonal_3_2_grid(self, painter: QPainter, rect: QRectF) -> None:  # pylint: disable=too-many-locals
         """
@@ -544,67 +488,7 @@ class GridOverlay:
             painter: QPainter object to draw with.
             rect: The rectangle area to draw the grid on.
         """
-        left = rect.left()
-        top = rect.top()
-        right = rect.right()
-        bottom = rect.bottom()
-        width = rect.width()
-        height = rect.height()
-
-        # For 3:2 ratio, for every 2 units horizontally, we go 3 units vertically
-        # slope = 3/2 = 1.5
-
-        # Diagonal from top-left corner (going down-right at ~56.31°)
-        if width * 3 <= height * 2:
-            # Hits right edge first: dx = width, dy = width * 3/2
-            end_x1 = right
-            end_y1 = top + width * 3.0 / 2.0
-        else:
-            # Hits bottom edge first: dy = height, dx = height * 2/3
-            end_x1 = left + height * 2.0 / 3.0
-            end_y1 = bottom
-
-        line1 = QLineF(left, top, end_x1, end_y1)
-        painter.drawLine(line1)
-
-        # Diagonal from top-right corner (going down-left)
-        if width * 3 <= height * 2:
-            # Hits left edge first
-            end_x2 = left
-            end_y2 = top + width * 3.0 / 2.0
-        else:
-            # Hits bottom edge first
-            end_x2 = right - height * 2.0 / 3.0
-            end_y2 = bottom
-
-        line2 = QLineF(right, top, end_x2, end_y2)
-        painter.drawLine(line2)
-
-        # Diagonal from bottom-left corner (going up-right)
-        if width * 3 <= height * 2:
-            # Hits right edge first
-            end_x3 = right
-            end_y3 = bottom - width * 3.0 / 2.0
-        else:
-            # Hits top edge first
-            end_x3 = left + height * 2.0 / 3.0
-            end_y3 = top
-
-        line3 = QLineF(left, bottom, end_x3, end_y3)
-        painter.drawLine(line3)
-
-        # Diagonal from bottom-right corner (going up-left)
-        if width * 3 <= height * 2:
-            # Hits left edge first
-            end_x4 = left
-            end_y4 = bottom - width * 3.0 / 2.0
-        else:
-            # Hits top edge first
-            end_x4 = right - height * 2.0 / 3.0
-            end_y4 = top
-
-        line4 = QLineF(right, bottom, end_x4, end_y4)
-        painter.drawLine(line4)
+        self._draw_diagonal_ratio_grid(painter, rect, vertical_ratio=3.0, horizontal_ratio=2.0)
 
     def _draw_diagonal_3_4_grid(self, painter: QPainter, rect: QRectF) -> None:  # pylint: disable=too-many-locals
         """
@@ -617,68 +501,7 @@ class GridOverlay:
             painter: QPainter object to draw with.
             rect: The rectangle area to draw the grid on.
         """
-        left = rect.left()
-        top = rect.top()
-        right = rect.right()
-        bottom = rect.bottom()
-        width = rect.width()
-        height = rect.height()
-
-        # For 3:4 ratio, for every 4 units horizontally, we go 3 units vertically
-        # slope = 3/4 = 0.75
-
-        # Diagonal from top-left corner (going down-right at 36.87°)
-        # dx/dy = 4/3, so dx = 4 * (dy/3)
-        if width * 3 <= height * 4:
-            # Hits right edge first: dx = width, dy = width * 3/4
-            end_x1 = right
-            end_y1 = top + width * 3.0 / 4.0
-        else:
-            # Hits bottom edge first: dy = height, dx = height * 4/3
-            end_x1 = left + height * 4.0 / 3.0
-            end_y1 = bottom
-
-        line1 = QLineF(left, top, end_x1, end_y1)
-        painter.drawLine(line1)
-
-        # Diagonal from top-right corner (going down-left at 143.13°)
-        if width * 3 <= height * 4:
-            # Hits left edge first
-            end_x2 = left
-            end_y2 = top + width * 3.0 / 4.0
-        else:
-            # Hits bottom edge first
-            end_x2 = right - height * 4.0 / 3.0
-            end_y2 = bottom
-
-        line2 = QLineF(right, top, end_x2, end_y2)
-        painter.drawLine(line2)
-
-        # Diagonal from bottom-left corner (going up-right at -36.87°/323.13°)
-        if width * 3 <= height * 4:
-            # Hits right edge first
-            end_x3 = right
-            end_y3 = bottom - width * 3.0 / 4.0
-        else:
-            # Hits top edge first
-            end_x3 = left + height * 4.0 / 3.0
-            end_y3 = top
-
-        line3 = QLineF(left, bottom, end_x3, end_y3)
-        painter.drawLine(line3)
-
-        # Diagonal from bottom-right corner (going up-left at -143.13°/216.87°)
-        if width * 3 <= height * 4:
-            # Hits left edge first
-            end_x4 = left
-            end_y4 = bottom - width * 3.0 / 4.0
-        else:
-            # Hits top edge first
-            end_x4 = right - height * 4.0 / 3.0
-            end_y4 = top
-
-        line4 = QLineF(right, bottom, end_x4, end_y4)
-        painter.drawLine(line4)
+        self._draw_diagonal_ratio_grid(painter, rect, vertical_ratio=3.0, horizontal_ratio=4.0)
 
     def _draw_diagonal_4_3_grid(self, painter: QPainter, rect: QRectF) -> None:  # pylint: disable=too-many-locals
         """
@@ -691,6 +514,15 @@ class GridOverlay:
             painter: QPainter object to draw with.
             rect: The rectangle area to draw the grid on.
         """
+        self._draw_diagonal_ratio_grid(painter, rect, vertical_ratio=4.0, horizontal_ratio=3.0)
+
+    def _draw_diagonal_ratio_grid(
+        self, painter: QPainter, rect: QRectF, vertical_ratio: float, horizontal_ratio: float
+    ) -> None:
+        """Draw corner-to-edge diagonal lines for a parameterized vertical:horizontal ratio."""
+        if vertical_ratio <= 0 or horizontal_ratio <= 0:
+            return
+
         left = rect.left()
         top = rect.top()
         right = rect.right()
@@ -698,58 +530,14 @@ class GridOverlay:
         width = rect.width()
         height = rect.height()
 
-        # For 4:3 ratio, for every 3 units horizontally, we go 4 units vertically
-        # slope = 4/3 ≈ 1.333
-
-        # Diagonal from top-left corner (going down-right at 53.13°)
-        # dx/dy = 3/4, so dx = 3 * (dy/4)
-        if width * 4 <= height * 3:
-            # Hits right edge first: dx = width, dy = width * 4/3
-            end_x1 = right
-            end_y1 = top + width * 4.0 / 3.0
+        if width * vertical_ratio <= height * horizontal_ratio:
+            x_offset = width
+            y_offset = width * vertical_ratio / horizontal_ratio
         else:
-            # Hits bottom edge first: dy = height, dx = height * 3/4
-            end_x1 = left + height * 3.0 / 4.0
-            end_y1 = bottom
+            x_offset = height * horizontal_ratio / vertical_ratio
+            y_offset = height
 
-        line1 = QLineF(left, top, end_x1, end_y1)
-        painter.drawLine(line1)
-
-        # Diagonal from top-right corner (going down-left at 126.87°)
-        if width * 4 <= height * 3:
-            # Hits left edge first
-            end_x2 = left
-            end_y2 = top + width * 4.0 / 3.0
-        else:
-            # Hits bottom edge first
-            end_x2 = right - height * 3.0 / 4.0
-            end_y2 = bottom
-
-        line2 = QLineF(right, top, end_x2, end_y2)
-        painter.drawLine(line2)
-
-        # Diagonal from bottom-left corner (going up-right at -53.13°/306.87°)
-        if width * 4 <= height * 3:
-            # Hits right edge first
-            end_x3 = right
-            end_y3 = bottom - width * 4.0 / 3.0
-        else:
-            # Hits top edge first
-            end_x3 = left + height * 3.0 / 4.0
-            end_y3 = top
-
-        line3 = QLineF(left, bottom, end_x3, end_y3)
-        painter.drawLine(line3)
-
-        # Diagonal from bottom-right corner (going up-left at -126.87°/233.13°)
-        if width * 4 <= height * 3:
-            # Hits left edge first
-            end_x4 = left
-            end_y4 = bottom - width * 4.0 / 3.0
-        else:
-            # Hits top edge first
-            end_x4 = right - height * 3.0 / 4.0
-            end_y4 = top
-
-        line4 = QLineF(right, bottom, end_x4, end_y4)
-        painter.drawLine(line4)
+        painter.drawLine(QLineF(left, top, left + x_offset, top + y_offset))
+        painter.drawLine(QLineF(right, top, right - x_offset, top + y_offset))
+        painter.drawLine(QLineF(left, bottom, left + x_offset, bottom - y_offset))
+        painter.drawLine(QLineF(right, bottom, right - x_offset, bottom - y_offset))

--- a/src/widgets/grid_settings_dialog.py
+++ b/src/widgets/grid_settings_dialog.py
@@ -28,8 +28,16 @@ from PyQt5.QtWidgets import QFrame, QHBoxLayout, QLabel, QListWidget, QPushButto
 GRID_TYPE_NONE = "none"
 GRID_TYPE_3X3 = "3x3"
 GRID_TYPE_GOLDEN_RATIO = "golden_ratio"
+GRID_TYPE_DIAGONAL_1_1 = "diagonal_1_1"
+GRID_TYPE_DIAGONAL_2_3 = "diagonal_2_3"
+GRID_TYPE_DIAGONAL_3_2 = "diagonal_3_2"
+GRID_TYPE_DIAGONAL_3_4 = "diagonal_3_4"
+GRID_TYPE_DIAGONAL_4_3 = "diagonal_4_3"
+GRID_TYPE_DIAGONAL_THIRDS_V = "diagonal_thirds_v"
+GRID_TYPE_DIAGONAL_THIRDS_H = "diagonal_thirds_h"
+GRID_TYPE_DIAGONAL_GOLDEN_V = "diagonal_golden_v"
+GRID_TYPE_DIAGONAL_GOLDEN_H = "diagonal_golden_h"
 # Future grid types can be added here:
-# GRID_TYPE_DIAGONAL = "diagonal"
 
 
 class GridSettingsDialog(QFrame):
@@ -51,8 +59,16 @@ class GridSettingsDialog(QFrame):
         ("None", GRID_TYPE_NONE),
         ("3x3 Grid", GRID_TYPE_3X3),
         ("Golden Ratio", GRID_TYPE_GOLDEN_RATIO),
+        ("Diagonal 1:1", GRID_TYPE_DIAGONAL_1_1),
+        ("Diagonal 2:3", GRID_TYPE_DIAGONAL_2_3),
+        ("Diagonal 3:2", GRID_TYPE_DIAGONAL_3_2),
+        ("Diagonal 3:4", GRID_TYPE_DIAGONAL_3_4),
+        ("Diagonal 4:3", GRID_TYPE_DIAGONAL_4_3),
+        ("Diagonal + Thirds V", GRID_TYPE_DIAGONAL_THIRDS_V),
+        ("Diagonal + Thirds H", GRID_TYPE_DIAGONAL_THIRDS_H),
+        ("Diagonal + Golden V", GRID_TYPE_DIAGONAL_GOLDEN_V),
+        ("Diagonal + Golden H", GRID_TYPE_DIAGONAL_GOLDEN_H),
         # Future grid types can be added here:
-        # ("Diagonal Lines", GRID_TYPE_DIAGONAL),
     ]
 
     def __init__(

--- a/src/widgets/grid_settings_dialog.py
+++ b/src/widgets/grid_settings_dialog.py
@@ -24,20 +24,20 @@ from typing import Optional
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import QFrame, QHBoxLayout, QLabel, QListWidget, QPushButton, QVBoxLayout, QWidget
 
-# Grid type constants
-GRID_TYPE_NONE = "none"
-GRID_TYPE_3X3 = "3x3"
-GRID_TYPE_GOLDEN_RATIO = "golden_ratio"
-GRID_TYPE_DIAGONAL_1_1 = "diagonal_1_1"
-GRID_TYPE_DIAGONAL_2_3 = "diagonal_2_3"
-GRID_TYPE_DIAGONAL_3_2 = "diagonal_3_2"
-GRID_TYPE_DIAGONAL_3_4 = "diagonal_3_4"
-GRID_TYPE_DIAGONAL_4_3 = "diagonal_4_3"
-GRID_TYPE_DIAGONAL_THIRDS_V = "diagonal_thirds_v"
-GRID_TYPE_DIAGONAL_THIRDS_H = "diagonal_thirds_h"
-GRID_TYPE_DIAGONAL_GOLDEN_V = "diagonal_golden_v"
-GRID_TYPE_DIAGONAL_GOLDEN_H = "diagonal_golden_h"
-# Future grid types can be added here:
+from .grid_types import (
+    GRID_TYPE_3X3,
+    GRID_TYPE_DIAGONAL_1_1,
+    GRID_TYPE_DIAGONAL_2_3,
+    GRID_TYPE_DIAGONAL_3_2,
+    GRID_TYPE_DIAGONAL_3_4,
+    GRID_TYPE_DIAGONAL_4_3,
+    GRID_TYPE_DIAGONAL_GOLDEN_H,
+    GRID_TYPE_DIAGONAL_GOLDEN_V,
+    GRID_TYPE_DIAGONAL_THIRDS_H,
+    GRID_TYPE_DIAGONAL_THIRDS_V,
+    GRID_TYPE_GOLDEN_RATIO,
+    GRID_TYPE_NONE,
+)
 
 
 class GridSettingsDialog(QFrame):

--- a/src/widgets/grid_types.py
+++ b/src/widgets/grid_types.py
@@ -1,0 +1,16 @@
+"""
+Shared grid type constants used by grid-related widgets.
+"""
+
+GRID_TYPE_NONE = "none"
+GRID_TYPE_3X3 = "3x3"
+GRID_TYPE_GOLDEN_RATIO = "golden_ratio"
+GRID_TYPE_DIAGONAL_1_1 = "diagonal_1_1"
+GRID_TYPE_DIAGONAL_2_3 = "diagonal_2_3"
+GRID_TYPE_DIAGONAL_3_2 = "diagonal_3_2"
+GRID_TYPE_DIAGONAL_3_4 = "diagonal_3_4"
+GRID_TYPE_DIAGONAL_4_3 = "diagonal_4_3"
+GRID_TYPE_DIAGONAL_THIRDS_V = "diagonal_thirds_v"
+GRID_TYPE_DIAGONAL_THIRDS_H = "diagonal_thirds_h"
+GRID_TYPE_DIAGONAL_GOLDEN_V = "diagonal_golden_v"
+GRID_TYPE_DIAGONAL_GOLDEN_H = "diagonal_golden_h"


### PR DESCRIPTION
# Pull Request

**What does this change do?**
Add multiple diagonal grid patterns to enhance composition options beyond rule-of-thirds and golden ratio layouts.
Diagonal grids provide additional composition guides for photographers, especially useful for dynamic and balanced compositions. Combined grids offer both diagonal tension and proportional division points.

Changes:
- Add 8 new diagonal grid type constants in grid_settings_dialog
- Implement diagonal line drawing for various aspect ratios (1:1, 2:3, 3:2, 3:4, 4:3)
- Add combined diagonal + thirds vertical/horizontal grids
- Add combined diagonal + golden ratio vertical/horizontal grids
- Use dictionary dispatch pattern for grid type selection in GridOverlay
- Import grid type constants from grid_settings_dialog to avoid duplication
- Add comprehensive docstrings explaining angles and slopes for each diagonal
- Update main window to handle all new grid types with status messages
- Calculate line endpoints based on rectangle bounds and aspect ratios


**Checklist:**
- [x] Targets `main` branch
- [x] I have tested my changes
- [x] I have verified against Python 3.8+
- [ ] I have updated documentation (if relevant)
- [ ] I have added or updated tests (if relevant)

**Additional notes**
<!-- Add any other information or context here -->
