### PR TITLE
Add autosave to persist session state between runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,4 @@ processed_images/
 checks/
 
 # Session/runtime state
-presets/autosave.json
+config/autosave.json

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ processed_images/
 
 # Check logs
 checks/
+
+# Session/runtime state
+presets/autosave.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,10 @@ COPY requirements.txt /opt/app/
 WORKDIR /opt/app
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Set up user workspace (only input/output/presets will be visible here)
+# Set up user workspace (only input/output/presets/config will be visible here)
 WORKDIR /app
-RUN mkdir -p /app/input /app/output /app/presets && \
-    chown qtuser:qtuser /app/input /app/output /app/presets
+RUN mkdir -p /app/input /app/output /app/presets /app/config && \
+    chown qtuser:qtuser /app/input /app/output /app/presets /app/config
 
 # Add application to Python path so it can be imported
 ENV PYTHONPATH="/opt/app:$PYTHONPATH"

--- a/run.sh
+++ b/run.sh
@@ -79,14 +79,22 @@ if [[ ! -d "$PRESETS_DIR" ]]; then
     create_directory_as_user "$PRESETS_DIR"
 fi
 
+CONFIG_DIR="$SCRIPT_DIR/config"
+if [[ ! -d "$CONFIG_DIR" ]]; then
+    echo "Creating config directory: $CONFIG_DIR"
+    create_directory_as_user "$CONFIG_DIR"
+fi
+
 # Final validation that directories are accessible
 validate_directory "$INPUT_DIR" "Input"
 validate_directory "$OUTPUT_DIR" "Output"
 validate_directory "$PRESETS_DIR" "Presets"
+validate_directory "$CONFIG_DIR" "Config"
 
 echo "Using input directory: $INPUT_DIR"
 echo "Using output directory: $OUTPUT_DIR"
 echo "Using presets directory: $PRESETS_DIR"
+echo "Using config directory: $CONFIG_DIR"
 
 # Enable X server access for Docker
 xhost +local:docker &>/dev/null || {
@@ -94,7 +102,7 @@ xhost +local:docker &>/dev/null || {
     exit 1
 }
 
-# Run container with GUI support and mounted input/output/presets folders
+# Run container with GUI support and mounted input/output/presets/config folders
 # All folders are mounted as read-write for data I/O
 # Source code is mounted as read-only
 docker run -it --rm \
@@ -104,6 +112,7 @@ docker run -it --rm \
     -v "$INPUT_DIR:/app/input:ro" \
     -v "$OUTPUT_DIR:/app/output" \
     -v "$PRESETS_DIR:/app/presets" \
+    -v "$CONFIG_DIR:/app/config" \
     -v "$SCRIPT_DIR/src:/opt/app/src:ro" \
     pyqt-app python3 -m src.main
 

--- a/src/handlers/autosave.py
+++ b/src/handlers/autosave.py
@@ -20,6 +20,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from typing import TYPE_CHECKING
 
@@ -60,8 +61,8 @@ def save_autosave(main_window: "MainWindow") -> None:
     try:
         with open(_autosave_path(main_window), "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
-    except OSError:
-        pass
+    except OSError as e:
+        logging.warning("Autosave write failed: %s", e)
 
 
 def restore_autosave(main_window: "MainWindow") -> None:  # pylint: disable=too-many-locals,too-many-branches
@@ -79,7 +80,7 @@ def restore_autosave(main_window: "MainWindow") -> None:  # pylint: disable=too-
     for i, name in enumerate(_CHANNEL_NAMES):
         ch_data = data.get("channels", {}).get(name, {})
         filepath = ch_data.get("path")
-        if filepath and os.path.exists(filepath):
+        if isinstance(filepath, str) and os.path.exists(filepath):
             load_channel_from_path(main_window, i, filepath)
 
     for i, name in enumerate(_CHANNEL_NAMES):
@@ -105,8 +106,8 @@ def restore_autosave(main_window: "MainWindow") -> None:  # pylint: disable=too-
         y = crop_data.get("y", 0)
         w = crop_data.get("width", 0)
         h = crop_data.get("height", 0)
-        if w > 0 and h > 0:
-            crop_rect = QRect(x, y, w, h)
+        if all(isinstance(v, (int, float)) for v in [x, y, w, h]) and w > 0 and h > 0:
+            crop_rect = QRect(int(x), int(y), int(w), int(h))
             main_window.viewer.set_saved_crop_rect(crop_rect)
             for i in range(3):
                 update_channel_preview(main_window, i)

--- a/src/handlers/autosave.py
+++ b/src/handlers/autosave.py
@@ -38,7 +38,7 @@ _SLIDER_NAMES = ["brightness", "contrast", "intensity"]
 
 def _autosave_path(main_window: "MainWindow") -> str:
     """Return the absolute path to the autosave JSON file."""
-    return os.path.join(main_window.presets_dir, _AUTOSAVE_FILENAME)  # type: ignore[arg-type]
+    return os.path.join(main_window.config_dir, _AUTOSAVE_FILENAME)  # type: ignore[arg-type]
 
 
 def save_autosave(main_window: "MainWindow") -> None:

--- a/src/handlers/autosave.py
+++ b/src/handlers/autosave.py
@@ -1,0 +1,123 @@
+# Copyright (C) 2025 fozga
+#
+# This file is part of Prokudin.
+#
+# Prokudin is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Prokudin is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Prokudin.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Autosave handler - persists session state (channel paths, sliders, crop) between app runs."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import TYPE_CHECKING
+
+from PyQt5.QtCore import QRect
+
+from .channels import adjust_channel, load_channel_from_path, update_channel_preview
+
+if TYPE_CHECKING:
+    from ..main_window import MainWindow
+
+_AUTOSAVE_FILENAME = "autosave.json"
+_CHANNEL_NAMES = ["red", "green", "blue"]
+_SLIDER_NAMES = ["brightness", "contrast", "intensity"]
+
+
+def _autosave_path(main_window: "MainWindow") -> str:
+    """Return the absolute path to the autosave JSON file."""
+    return os.path.join(main_window.presets_dir, _AUTOSAVE_FILENAME)  # type: ignore[arg-type]
+
+
+def save_autosave(main_window: "MainWindow") -> None:
+    """Save current channel paths, slider values, and crop rect to the autosave file."""
+    channels: dict = {}
+    for i, name in enumerate(_CHANNEL_NAMES):
+        ctrl = main_window.controllers[i]
+        channels[name] = {
+            "path": main_window.channel_paths[i],
+            **{s: ctrl.sliders[s].value() for s in _SLIDER_NAMES},
+        }
+
+    saved_crop = main_window.viewer.get_saved_crop_rect() if main_window.viewer else None
+    crop = None
+    if saved_crop and saved_crop.isValid():
+        crop = {"x": saved_crop.x(), "y": saved_crop.y(), "width": saved_crop.width(), "height": saved_crop.height()}
+
+    data = {"version": 1, "channels": channels, "crop": crop}
+
+    try:
+        with open(_autosave_path(main_window), "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+    except OSError:
+        pass
+
+
+def restore_autosave(main_window: "MainWindow") -> None:  # pylint: disable=too-many-locals,too-many-branches
+    """Load session state from the autosave file and restore channel images, sliders, and crop."""
+    path = _autosave_path(main_window)
+    if not os.path.exists(path):
+        return
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return
+
+    for i, name in enumerate(_CHANNEL_NAMES):
+        ch_data = data.get("channels", {}).get(name, {})
+        filepath = ch_data.get("path")
+        if filepath and os.path.exists(filepath):
+            load_channel_from_path(main_window, i, filepath)
+
+    for i, name in enumerate(_CHANNEL_NAMES):
+        ch_data = data.get("channels", {}).get(name, {})
+        ctrl = main_window.controllers[i]
+        ctrl.blockSignals(True)
+        for slider_name in _SLIDER_NAMES:
+            value = ch_data.get(slider_name)
+            if isinstance(value, int) and slider_name in ctrl.sliders:
+                ctrl.sliders[slider_name].setValue(value)
+                if slider_name in ctrl.text_inputs:
+                    ctrl.text_inputs[slider_name].setText(str(value))
+        ctrl.blockSignals(False)
+
+    for i in range(3):
+        if main_window.aligned[i] is not None:
+            adjust_channel(main_window, i)
+        update_channel_preview(main_window, i)
+
+    crop_data = data.get("crop")
+    if isinstance(crop_data, dict):
+        x = crop_data.get("x", 0)
+        y = crop_data.get("y", 0)
+        w = crop_data.get("width", 0)
+        h = crop_data.get("height", 0)
+        if w > 0 and h > 0:
+            crop_rect = QRect(x, y, w, h)
+            main_window.viewer.set_saved_crop_rect(crop_rect)
+            for i in range(3):
+                update_channel_preview(main_window, i)
+
+    main_window.update_save_button_state()
+    main_window.status_handler.set_message("Session restored", main_window.status_handler.MEDIUM_TIMEOUT)
+
+
+def clear_autosave(main_window: "MainWindow") -> None:
+    """Remove the autosave file (called on app reset)."""
+    try:
+        os.remove(_autosave_path(main_window))
+    except OSError:
+        pass

--- a/src/handlers/channels.py
+++ b/src/handlers/channels.py
@@ -113,8 +113,11 @@ def load_channel(main_window: "MainWindow", channel_idx: int) -> None:
         main_window.channel_paths[channel_idx] = file_path
         _process_channel_image(main_window, channel_idx, rgb_image)
     else:
-        if err_msg and err_msg != "No file selected":
-            main_window.status_handler.set_message(err_msg, main_window.status_handler.LONG_TIMEOUT)
+        if err_msg != "No file selected":
+            main_window.status_handler.set_message(
+                err_msg or "Failed to load image. Please try again.",
+                main_window.status_handler.LONG_TIMEOUT,
+            )
 
 
 def load_channel_from_path(main_window: "MainWindow", channel_idx: int, file_path: str) -> None:
@@ -126,10 +129,15 @@ def load_channel_from_path(main_window: "MainWindow", channel_idx: int, file_pat
         channel_idx (int): Index of the channel to load (0=R, 1=G, 2=B).
         file_path (str): Absolute path to the ARW file.
     """
-    rgb_image, _ = load_raw_image_from_path(file_path)
+    rgb_image, err_msg = load_raw_image_from_path(file_path)
     if rgb_image is not None:
         main_window.channel_paths[channel_idx] = file_path
         _process_channel_image(main_window, channel_idx, rgb_image)
+    elif err_msg:
+        main_window.status_handler.set_message(
+            f"Failed to restore {_CHANNEL_NAMES.get(channel_idx, 'Unknown')} channel: {err_msg}",
+            main_window.status_handler.LONG_TIMEOUT,
+        )
 
 
 def adjust_channel(main_window: "MainWindow", channel_idx: int) -> None:

--- a/src/handlers/channels.py
+++ b/src/handlers/channels.py
@@ -37,109 +37,99 @@ if TYPE_CHECKING:
 from ..core.align import align_images
 from ..core.image_processing import apply_adjustments
 from .display import update_main_display
-from .image_loading import load_raw_image
+from .image_loading import load_raw_image, load_raw_image_from_path
+
+_CHANNEL_NAMES = {0: "Red", 1: "Green", 2: "Blue"}
 
 
-def load_channel(main_window: "MainWindow", channel_idx: int) -> None:  # pylint: disable=too-many-locals
+def _process_channel_image(main_window: "MainWindow", channel_idx: int, rgb_image: np.ndarray) -> None:
+    """Store and process a loaded RGB image for the given channel, triggering alignment when all 3 are ready."""
+
+    original_rgb_images: List[Optional[np.ndarray]] = list(main_window.original_rgb_images)
+    original_rgb_images[channel_idx] = rgb_image
+    main_window.original_rgb_images = original_rgb_images  # type: ignore
+
+    image = cv2.cvtColor(rgb_image, cv2.COLOR_RGB2GRAY)  # pylint: disable=E1101
+
+    original_images: List[Optional[np.ndarray]] = list(main_window.original_images)
+    processed: List[Optional[np.ndarray]] = list(main_window.processed)
+
+    original_images[channel_idx] = image
+    processed[channel_idx] = image.copy()
+
+    main_window.original_images = original_images  # type: ignore
+    main_window.processed = processed  # type: ignore
+
+    main_window.status_handler.set_message(
+        f"Successfully loaded image into {_CHANNEL_NAMES.get(channel_idx, 'Unknown')} channel",
+        main_window.status_handler.MEDIUM_TIMEOUT,
+    )
+
+    if all(img is not None for img in main_window.original_images):
+        gray_images: List[np.ndarray] = []
+        rgb_images: List[np.ndarray] = []
+
+        for i in range(3):
+            if main_window.original_images[i] is not None and main_window.original_rgb_images[i] is not None:
+                gray_img = cast(np.ndarray, main_window.original_images[i])
+                rgb_img = cast(np.ndarray, main_window.original_rgb_images[i])
+                gray_images.append(gray_img)
+                rgb_images.append(rgb_img)
+
+        if len(gray_images) == 3 and len(rgb_images) == 3:
+            main_window.status_handler.set_message("Aligning images, please wait...")
+            aligned_gray, aligned_rgb = align_images(gray_images, rgb_images)
+
+            main_window.aligned = aligned_gray  # type: ignore
+            main_window.aligned_rgb = aligned_rgb  # type: ignore
+
+            new_processed: List[Optional[np.ndarray]] = [img.copy() for img in aligned_gray]
+            main_window.processed = new_processed  # type: ignore
+
+            for i in range(3):
+                adjust_channel(main_window, i)
+                update_channel_preview(main_window, i)
+            main_window.status_handler.set_message(
+                "All channels loaded successfully - Ready for editing!", main_window.status_handler.NO_TIMEOUT
+            )
+    else:
+        update_channel_preview(main_window, channel_idx)
+
+    update_main_display(main_window)
+    main_window.update_save_button_state()
+
+
+def load_channel(main_window: "MainWindow", channel_idx: int) -> None:
     """
-    Loads a raw image file for the specified color channel, updates the application's state,
-    and triggers alignment and preview updates.
+    Opens a file dialog, loads a raw image for the specified channel, and updates application state.
 
     Args:
-        main_window (MainWindow): Reference to the main application window containing image state and UI.
+        main_window (MainWindow): Reference to the main application window.
         channel_idx (int): Index of the channel to load (0=R, 1=G, 2=B).
-
-    Returns:
-        None
-
-    Cross-references:
-        - load_raw_image
-        - align_images
-        - adjust_channel
-        - update_channel_preview
-        - update_main_display
     """
-    # Channel names for status messages
-    channel_names = {0: "Red", 1: "Green", 2: "Blue"}
-    channel_name = channel_names.get(channel_idx, "Unknown")
+    rgb_image, file_path, err_msg = load_raw_image(main_window)
 
-    # Load the RGB image
-    rgb_image, err_msg = load_raw_image(main_window)
-
-    if rgb_image is not None:
-        # Create a new list to avoid assignment issues
-        original_rgb_images: List[Optional[np.ndarray]] = list(main_window.original_rgb_images)
-        original_rgb_images[channel_idx] = rgb_image
-        main_window.original_rgb_images = original_rgb_images  # type: ignore
-
-        # Convert RGB to grayscale
-        image = cv2.cvtColor(rgb_image, cv2.COLOR_RGB2GRAY)  # pylint: disable=E1101
-
-        # Create new lists with proper type annotations to avoid assignment issues
-        original_images: List[Optional[np.ndarray]] = list(main_window.original_images)
-        processed: List[Optional[np.ndarray]] = list(main_window.processed)
-
-        original_images[channel_idx] = image
-        processed[channel_idx] = image.copy()
-
-        # Assign back to main_window
-        main_window.original_images = original_images  # type: ignore
-        main_window.processed = processed  # type: ignore
-
-        # Display status message showing which channel was loaded
-        main_window.status_handler.set_message(
-            f"Successfully loaded image into {channel_name} channel", main_window.status_handler.MEDIUM_TIMEOUT
-        )
-
-        if all(img is not None for img in main_window.original_images):
-            # Create arrays of ndarray images only, with explicit type casting for mypy
-            gray_images: List[np.ndarray] = []
-            rgb_images: List[np.ndarray] = []
-
-            # Only include non-None images and cast them to numpy arrays
-            for i in range(3):
-                if main_window.original_images[i] is not None and main_window.original_rgb_images[i] is not None:
-                    gray_img = cast(np.ndarray, main_window.original_images[i])
-                    rgb_img = cast(np.ndarray, main_window.original_rgb_images[i])
-                    gray_images.append(gray_img)
-                    rgb_images.append(rgb_img)
-
-            # Ensure we have exactly 3 images for each channel
-            if len(gray_images) == 3 and len(rgb_images) == 3:
-                # Align both grayscale and RGB images
-                main_window.status_handler.set_message("Aligning images, please wait...")
-                aligned_gray, aligned_rgb = align_images(gray_images, rgb_images)
-
-                # Store aligned grayscale images
-                main_window.aligned = aligned_gray  # type: ignore
-
-                # Store aligned RGB images
-                main_window.aligned_rgb = aligned_rgb  # type: ignore
-
-                # Create new list with copies of aligned images
-                new_processed: List[Optional[np.ndarray]] = []
-                for img in aligned_gray:
-                    new_processed.append(img.copy())
-
-                main_window.processed = new_processed  # type: ignore
-
-                for i in range(3):
-                    adjust_channel(main_window, i)
-                    update_channel_preview(main_window, i)
-                main_window.status_handler.set_message(
-                    "All channels loaded successfully - Ready for editing!", main_window.status_handler.NO_TIMEOUT
-                )
-        else:
-            update_channel_preview(main_window, channel_idx)
-        update_main_display(main_window)
-
-        # After successfully loading a channel, update save button state
-        main_window.update_save_button_state()
+    if rgb_image is not None and file_path is not None:
+        main_window.channel_paths[channel_idx] = file_path
+        _process_channel_image(main_window, channel_idx, rgb_image)
     else:
-        # Display error message if loading failed
-        if err_msg is None:
-            err_msg = "Failed to load image. Please try again."
-        main_window.status_handler.set_message(err_msg, main_window.status_handler.LONG_TIMEOUT)
+        if err_msg and err_msg != "No file selected":
+            main_window.status_handler.set_message(err_msg, main_window.status_handler.LONG_TIMEOUT)
+
+
+def load_channel_from_path(main_window: "MainWindow", channel_idx: int, file_path: str) -> None:
+    """
+    Load a channel from a known file path without opening a dialog (used for session restore).
+
+    Args:
+        main_window (MainWindow): Reference to the main application window.
+        channel_idx (int): Index of the channel to load (0=R, 1=G, 2=B).
+        file_path (str): Absolute path to the ARW file.
+    """
+    rgb_image, _ = load_raw_image_from_path(file_path)
+    if rgb_image is not None:
+        main_window.channel_paths[channel_idx] = file_path
+        _process_channel_image(main_window, channel_idx, rgb_image)
 
 
 def adjust_channel(main_window: "MainWindow", channel_idx: int) -> None:

--- a/src/handlers/image_loading.py
+++ b/src/handlers/image_loading.py
@@ -27,48 +27,19 @@ import rawpy  # type: ignore
 from PyQt5.QtWidgets import QFileDialog, QWidget
 
 
-def load_raw_image(parent: QWidget) -> Union[tuple[np.ndarray, None], tuple[None, str]]:
+def load_raw_image_from_path(file_path: str) -> Union[tuple[np.ndarray, None], tuple[None, str]]:
     """
-    Opens a file dialog for the user to select a Sony ARW RAW image,
-    loads the image using rawpy, and processes it to an 8-bit RGB image.
+    Load a Sony ARW RAW image from a known file path without opening a file dialog.
 
     Args:
-        parent (QWidget): The parent widget for the QFileDialog (typically the main window).
+        file_path (str): Absolute path to the ARW file.
 
     Returns:
-        tuple: Either (numpy.ndarray, None) with the 3D RGB image as a NumPy array
-        (dtype=uint8, shape: HxWx3) and no error, or (None, str) with an error message
-        if loading fails or is cancelled.
-
-    Workflow:
-        1. Opens a QFileDialog for ARW file selection.
-        2. Loads the selected file with rawpy and applies camera white balance.
-        3. Disables automatic brightness correction, outputs 8 bits per sample.
-        4. Returns the RGB image directly for further processing.
-        5. Handles errors gracefully, returning None and an error message.
-
-    Example:
-        rgb_image, error = load_raw_image(self)
-        if error:
-            print(error)
-        elif rgb_image is not None:
-            # Convert to grayscale if needed
-            gray_image = cv2.cvtColor(rgb_image, cv2.COLOR_RGB2GRAY)
-            # Proceed with processing
-
-    Cross-references:
-        - handlers.channels.load_channel
+        tuple: Either (numpy.ndarray, None) on success or (None, str) with an error message.
     """
-    options = QFileDialog.Options()
-    filename, _ = QFileDialog.getOpenFileName(parent, "Select ARW File", "", "Sony RAW Files (*.arw)", options=options)
-
-    if not filename:
-        return None, "No file selected"
-
     try:
-        with rawpy.imread(filename) as raw:
+        with rawpy.imread(file_path) as raw:
             rgb = raw.postprocess(use_camera_wb=True, no_auto_bright=True, output_bps=8)
-        # Return the RGB image directly without converting to grayscale
         result: np.ndarray = rgb
         return result, None
     except (
@@ -77,5 +48,30 @@ def load_raw_image(parent: QWidget) -> Union[tuple[np.ndarray, None], tuple[None
         FileNotFoundError,
         PermissionError,
     ) as e:  # pylint: disable=E1101
-        error_message = f"Error loading ARW file: {e}"
-        return None, error_message
+        return None, f"Error loading ARW file: {e}"
+
+
+def load_raw_image(parent: QWidget) -> Union[tuple[np.ndarray, str, None], tuple[None, None, str]]:
+    """
+    Opens a file dialog for the user to select a Sony ARW RAW image,
+    loads the image using rawpy, and processes it to an 8-bit RGB image.
+
+    Args:
+        parent (QWidget): The parent widget for the QFileDialog (typically the main window).
+
+    Returns:
+        tuple: Either (numpy.ndarray, path, None) on success or (None, None, str) with an error.
+
+    Cross-references:
+        - handlers.channels.load_channel
+    """
+    options = QFileDialog.Options()
+    filename, _ = QFileDialog.getOpenFileName(parent, "Select ARW File", "", "Sony RAW Files (*.arw)", options=options)
+
+    if not filename:
+        return None, None, "No file selected"
+
+    rgb_image, err = load_raw_image_from_path(filename)
+    if rgb_image is not None:
+        return rgb_image, filename, None
+    return None, None, err or "Unknown error"

--- a/src/main_window.py
+++ b/src/main_window.py
@@ -24,13 +24,14 @@ import os
 from typing import Callable, Union
 
 from PyQt5.QtCore import QRect, Qt, QTimer
-from PyQt5.QtGui import QKeyEvent, QMouseEvent
+from PyQt5.QtGui import QCloseEvent, QKeyEvent, QMouseEvent
 from PyQt5.QtWidgets import (
     QApplication,
     QComboBox,
     QHBoxLayout,
     QLabel,
     QMainWindow,
+    QMessageBox,
     QPushButton,
     QStatusBar,
     QVBoxLayout,
@@ -831,6 +832,33 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
 
         # Update mode indicator based on loaded channels
         self._update_mode_from_state()
+
+    def closeEvent(self, event: Union[QCloseEvent, None]) -> None:  # pylint: disable=C0103
+        """
+        Prompt the user to save session state when closing the window.
+
+        If the user chooses not to save, the autosave file is cleared so the
+        next launch opens with a clean state. Choosing Cancel aborts the close.
+
+        Args:
+            event: The close event.
+        """
+        if event is None:
+            return
+        if any(img is not None for img in self.original_images):
+            reply = QMessageBox.question(
+                self,
+                "Save Session",
+                "Save session state for next launch?",
+                QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel,  # type: ignore[attr-defined]
+                QMessageBox.Yes,  # type: ignore[attr-defined]
+            )
+            if reply == QMessageBox.Cancel:  # type: ignore[attr-defined]
+                event.ignore()
+                return
+            if reply == QMessageBox.No:  # type: ignore[attr-defined]
+                clear_autosave(self)
+        event.accept()
 
     def keyPressEvent(self, event: Union[QKeyEvent, None]) -> None:  # pylint: disable=C0103
         """

--- a/src/main_window.py
+++ b/src/main_window.py
@@ -133,39 +133,10 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
         # Grid settings dialog (initially None, created on demand)
         self.grid_settings_dialog: Union[GridSettingsDialog, None] = None
 
-        # Path to the presets folder with fallback strategy
-        # Try to find the project root by looking for requirements.txt
-        def find_project_root() -> str:
-            current = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-            for _ in range(5):  # Search up to 5 levels
-                if os.path.exists(os.path.join(current, "requirements.txt")):
-                    return current
-                parent = os.path.dirname(current)
-                if parent == current:  # Reached filesystem root
-                    break
-                current = parent
-            return current
-
-        project_root = find_project_root()
-        preset_options = [
-            "/app/presets",  # Container workspace (mounted as read-write)
-            os.path.join(project_root, "presets"),  # Project directory
-            os.path.expanduser("~/.config/prokudin/presets"),  # User home
-        ]
-
-        self.presets_dir = None
-        for preset_path in preset_options:
-            try:
-                os.makedirs(preset_path, exist_ok=True)
-                self.presets_dir = preset_path
-                break
-            except (OSError, PermissionError):
-                continue
-
-        if self.presets_dir is None:
-            raise RuntimeError("Failed to create presets directory in any location")
+        self.presets_dir, self.config_dir = self._resolve_dirs()
 
         assert self.presets_dir is not None
+        assert self.config_dir is not None
         self.init_ui()
 
         # Debounce timer: autosave fires 500 ms after the last slider change
@@ -179,6 +150,44 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
 
         # Restore previous session (loads images, sets sliders, applies crop)
         restore_autosave(self)
+
+    def _resolve_dirs(self) -> tuple[str, str]:
+        """
+        Locate writable presets and config directories, trying container paths first then local fallbacks.
+
+        Returns:
+            tuple: (presets_dir, config_dir) absolute paths.
+        """
+        current = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        project_root = current
+        for _ in range(5):
+            if os.path.exists(os.path.join(current, "requirements.txt")):
+                project_root = current
+                break
+            parent = os.path.dirname(current)
+            if parent == current:
+                break
+            current = parent
+
+        def _first_writable(candidates: list[str], label: str) -> str:
+            """Return the first candidate path that can be created with write permissions."""
+            for path in candidates:
+                try:
+                    os.makedirs(path, exist_ok=True)
+                    return path
+                except (OSError, PermissionError):
+                    continue
+            raise RuntimeError(f"Failed to create {label} directory in any location")
+
+        presets_dir = _first_writable(
+            ["/app/presets", os.path.join(project_root, "presets"), os.path.expanduser("~/.config/prokudin/presets")],
+            "presets",
+        )
+        config_dir = _first_writable(
+            ["/app/config", os.path.join(project_root, "config"), os.path.expanduser("~/.config/prokudin")],
+            "config",
+        )
+        return presets_dir, config_dir
 
     def init_ui(self) -> None:  # pylint: disable=too-many-statements
         """

--- a/src/main_window.py
+++ b/src/main_window.py
@@ -23,7 +23,7 @@ Handles state management, user interactions, and connects UI components to proce
 import os
 from typing import Callable, Union
 
-from PyQt5.QtCore import QRect, Qt
+from PyQt5.QtCore import QRect, Qt, QTimer
 from PyQt5.QtGui import QKeyEvent, QMouseEvent
 from PyQt5.QtWidgets import (
     QApplication,
@@ -38,6 +38,7 @@ from PyQt5.QtWidgets import (
 )
 
 from .default_state import DefaultState
+from .handlers.autosave import clear_autosave, restore_autosave, save_autosave
 from .handlers.channels import adjust_channel, load_channel, show_single_channel, update_channel_preview
 from .handlers.display import show_combined_image, show_single_channel_image, update_main_display
 from .handlers.image_saving import save_image_with_dialog
@@ -117,6 +118,9 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
         self.original_rgb_images = [None, None, None]
         self.aligned_rgb = [None, None, None]
 
+        # File paths for loaded channels (used for autosave/restore)
+        self.channel_paths: list[str | None] = [None, None, None]
+
         # Display state - use defaults from DefaultState
         self.show_combined = DefaultState.SHOW_COMBINED
         self.current_channel = DefaultState.CURRENT_CHANNEL
@@ -164,8 +168,17 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
         assert self.presets_dir is not None
         self.init_ui()
 
+        # Debounce timer: autosave fires 500 ms after the last slider change
+        self._autosave_timer = QTimer()
+        self._autosave_timer.setSingleShot(True)
+        self._autosave_timer.setInterval(500)
+        self._autosave_timer.timeout.connect(lambda: save_autosave(self))
+
         # Update the mode based on initial state
         self._update_mode_from_state()
+
+        # Restore previous session (loads images, sets sliders, applies crop)
+        restore_autosave(self)
 
     def init_ui(self) -> None:  # pylint: disable=too-many-statements
         """
@@ -276,9 +289,11 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
         for idx, controller in enumerate(self.controllers):
             # Connect load button and sliders to handlers
             controller.btn_load.clicked.connect(lambda _, i=idx: load_channel(self, i))
+            controller.btn_load.clicked.connect(lambda _, i=idx: save_autosave(self))
 
             # Connect controller value changes to adjust channel (handles both slider and text input)
             controller.value_changed.connect(lambda i=idx: adjust_channel(self, i))
+            controller.value_changed.connect(self._schedule_autosave)
 
             # Fix the mousePressEvent assignment with properly typed functions
             # Pass controller as an argument to avoid cell-var-from-loop issue
@@ -575,6 +590,8 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
         else:
             show_single_channel_image(self)
 
+        save_autosave(self)
+
     def save_images(self) -> None:
         """
         Handle save button click by opening save dialog and saving images.
@@ -622,6 +639,7 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
         self.processed = [None, None, None]
         self.original_rgb_images = [None, None, None]
         self.aligned_rgb = [None, None, None]
+        self.channel_paths = [None, None, None]
 
         # Reset display state to defaults
         self.show_combined = DefaultState.SHOW_COMBINED
@@ -657,6 +675,8 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
 
         # Update UI state (manages save and crop button states, and mode indicator)
         self.update_save_button_state()
+
+        clear_autosave(self)
 
         # Show status message
         self.status_handler.set_message("Application reset to default state", self.status_handler.MEDIUM_TIMEOUT)
@@ -777,6 +797,10 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
         # Refresh the display
         self.viewer.viewport().update()  # type: ignore[union-attr]
         self.status_handler.set_message(f"Grid line width: {width}px", self.status_handler.SHORT_TIMEOUT)
+
+    def _schedule_autosave(self) -> None:
+        """Restart the debounce timer so autosave fires 500 ms after the last slider change."""
+        self._autosave_timer.start()
 
     def update_save_button_state(self) -> None:
         """


### PR DESCRIPTION
# Pull Request

**What does this change do?**
Saves channel file paths, slider values, and crop rect to presets/autosave.json on every change (debounced 500 ms for sliders). Restores full session automatically on next launch, including re-loading images, re-applying adjustments, and restoring the crop. Clears autosave when the user hits New.

**Checklist:**
- [x] Targets `main` branch
- [x] I have tested my changes
- [x] I have verified against Python 3.8+
- [x] I have updated documentation (if relevant)
- [ ] I have added or updated tests (if relevant)
