### PR TITLE
Mirror CI check parameters in local run script

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,8 @@ black==24.1.1
 isort==5.13.2
 flake8==7.0.0
 pylint==3.0.3
-mypy==1.8.0
+mypy==1.16.1
+PyQt5-stubs==5.15.8.0.1
 interrogate==1.5.0
+pip-licenses==4.3.4
 setuptools==69.1.0

--- a/run_checks.py
+++ b/run_checks.py
@@ -60,7 +60,7 @@ def run_checks() -> int:
         ("flake8", ["flake8", "src/"]),
         ("pylint", ["pylint", "src/"]),
         ("mypy", ["mypy", "--explicit-package-bases", "src/"]),
-        ("interrogate", ["interrogate", "--ignore-init-method", "--fail-under=100", "-vv", "."]),
+        ("interrogate", ["interrogate", "--ignore-init-method", "--fail-under=100", "--exclude=.venv", "-vv", "."]),
         ("pip-licenses", ["pip-licenses", "--from=mixed", "--fail-on=restricted"]),
     ]
 

--- a/run_checks.py
+++ b/run_checks.py
@@ -57,10 +57,11 @@ def run_checks() -> int:
     checks = [
         ("black", ["black", "--check", "src/"]),
         ("isort", ["isort", "--check-only", "src/"]),
-        ("flake8", ["flake8", "src/", "--max-line-length=120"]),
+        ("flake8", ["flake8", "src/"]),
         ("pylint", ["pylint", "src/"]),
-        ("mypy", ["mypy", "src/"]),
-        ("interrogate", ["interrogate", "--ignore-init-method", "--fail-under=100", "--exclude=.venv", "src/"]),
+        ("mypy", ["mypy", "--explicit-package-bases", "src/"]),
+        ("interrogate", ["interrogate", "--ignore-init-method", "--fail-under=100", "-vv", "."]),
+        ("pip-licenses", ["pip-licenses", "--from=mixed", "--fail-on=restricted"]),
     ]
 
     failed = []


### PR DESCRIPTION
# Pull Request

**What does this change do?**
Align local checks with CI parameters

- Remove flake8 --max-line-length=120 to use CI defaults
- Add mypy --explicit-package-bases flag
- Change interrogate to run on entire repo (.) instead of src/
- Update mypy to 1.16.1 to match CI version
- Add PyQt5-stubs for type checking
- Add pip-licenses check for license compliance

**Checklist:**
- [x] Targets `main` branch
- [x] I have tested my changes
- [x] I have verified against Python 3.8+
- [x] I have updated documentation (if relevant)
- [ ] I have added or updated tests (if relevant)
