### PR TITLE
Extract mutable MainWindow state into AppState dataclass

### DIFF
--- a/src/app_state.py
+++ b/src/app_state.py
@@ -1,0 +1,68 @@
+# Copyright (C) 2025 fozga
+#
+# This file is part of Prokudin.
+#
+# Prokudin is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Prokudin is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Prokudin.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Mutable application state dataclass for the Prokudin main window."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    import numpy as np
+    from PyQt5.QtCore import QRect
+
+    from .widgets.grid_settings_dialog import GridSettingsDialog
+
+from .default_state import DefaultState
+
+
+@dataclass
+class AppState:  # pylint: disable=too-few-public-methods,too-many-instance-attributes
+    """Centralised mutable state owned by MainWindow.
+
+    All fields are initialised to their default values on construction.
+    Call reset() to restore defaults after a session ends.
+    """
+
+    original_images: List[Optional[np.ndarray]] = field(default_factory=lambda: [None, None, None])
+    aligned: List[Optional[np.ndarray]] = field(default_factory=lambda: [None, None, None])
+    processed: List[Optional[np.ndarray]] = field(default_factory=lambda: [None, None, None])
+    original_rgb_images: List[Optional[np.ndarray]] = field(default_factory=lambda: [None, None, None])
+    aligned_rgb: List[Optional[np.ndarray]] = field(default_factory=lambda: [None, None, None])
+    channel_paths: List[Optional[str]] = field(default_factory=lambda: [None, None, None])
+    show_combined: bool = DefaultState.SHOW_COMBINED
+    current_channel: int = DefaultState.CURRENT_CHANNEL
+    crop_mode: bool = DefaultState.CROP_MODE
+    crop_rect: Optional[QRect] = None
+    crop_ratio: Optional[Tuple[int, int]] = None
+    grid_settings_dialog: Optional[GridSettingsDialog] = None
+
+    def reset(self) -> None:
+        """Restore every field to its default value."""
+        self.original_images = [None, None, None]
+        self.aligned = [None, None, None]
+        self.processed = [None, None, None]
+        self.original_rgb_images = [None, None, None]
+        self.aligned_rgb = [None, None, None]
+        self.channel_paths = [None, None, None]
+        self.show_combined = DefaultState.SHOW_COMBINED
+        self.current_channel = DefaultState.CURRENT_CHANNEL
+        self.crop_mode = DefaultState.CROP_MODE
+        self.crop_rect = None
+        self.crop_ratio = None
+        self.grid_settings_dialog = None

--- a/src/handlers/autosave.py
+++ b/src/handlers/autosave.py
@@ -47,7 +47,7 @@ def save_autosave(main_window: "MainWindow") -> None:
     for i, name in enumerate(_CHANNEL_NAMES):
         ctrl = main_window.controllers[i]
         channels[name] = {
-            "path": main_window.channel_paths[i],
+            "path": main_window.state.channel_paths[i],
             **{s: ctrl.sliders[s].value() for s in _SLIDER_NAMES},
         }
 
@@ -96,7 +96,7 @@ def restore_autosave(main_window: "MainWindow") -> None:  # pylint: disable=too-
         ctrl.blockSignals(False)
 
     for i in range(3):
-        if main_window.aligned[i] is not None:
+        if main_window.state.aligned[i] is not None:
             adjust_channel(main_window, i)
         update_channel_preview(main_window, i)
 

--- a/src/handlers/channels.py
+++ b/src/handlers/channels.py
@@ -45,34 +45,37 @@ _CHANNEL_NAMES = {0: "Red", 1: "Green", 2: "Blue"}
 def _process_channel_image(main_window: "MainWindow", channel_idx: int, rgb_image: np.ndarray) -> None:
     """Store and process a loaded RGB image for the given channel, triggering alignment when all 3 are ready."""
 
-    original_rgb_images: List[Optional[np.ndarray]] = list(main_window.original_rgb_images)
+    original_rgb_images: List[Optional[np.ndarray]] = list(main_window.state.original_rgb_images)
     original_rgb_images[channel_idx] = rgb_image
-    main_window.original_rgb_images = original_rgb_images  # type: ignore
+    main_window.state.original_rgb_images = original_rgb_images  # type: ignore
 
     image = cv2.cvtColor(rgb_image, cv2.COLOR_RGB2GRAY)  # pylint: disable=E1101
 
-    original_images: List[Optional[np.ndarray]] = list(main_window.original_images)
-    processed: List[Optional[np.ndarray]] = list(main_window.processed)
+    original_images: List[Optional[np.ndarray]] = list(main_window.state.original_images)
+    processed: List[Optional[np.ndarray]] = list(main_window.state.processed)
 
     original_images[channel_idx] = image
     processed[channel_idx] = image.copy()
 
-    main_window.original_images = original_images  # type: ignore
-    main_window.processed = processed  # type: ignore
+    main_window.state.original_images = original_images  # type: ignore
+    main_window.state.processed = processed  # type: ignore
 
     main_window.status_handler.set_message(
         f"Successfully loaded image into {_CHANNEL_NAMES.get(channel_idx, 'Unknown')} channel",
         main_window.status_handler.MEDIUM_TIMEOUT,
     )
 
-    if all(img is not None for img in main_window.original_images):
+    if all(img is not None for img in main_window.state.original_images):
         gray_images: List[np.ndarray] = []
         rgb_images: List[np.ndarray] = []
 
         for i in range(3):
-            if main_window.original_images[i] is not None and main_window.original_rgb_images[i] is not None:
-                gray_img = cast(np.ndarray, main_window.original_images[i])
-                rgb_img = cast(np.ndarray, main_window.original_rgb_images[i])
+            if (
+                main_window.state.original_images[i] is not None
+                and main_window.state.original_rgb_images[i] is not None
+            ):
+                gray_img = cast(np.ndarray, main_window.state.original_images[i])
+                rgb_img = cast(np.ndarray, main_window.state.original_rgb_images[i])
                 gray_images.append(gray_img)
                 rgb_images.append(rgb_img)
 
@@ -80,11 +83,11 @@ def _process_channel_image(main_window: "MainWindow", channel_idx: int, rgb_imag
             main_window.status_handler.set_message("Aligning images, please wait...")
             aligned_gray, aligned_rgb = align_images(gray_images, rgb_images)
 
-            main_window.aligned = aligned_gray  # type: ignore
-            main_window.aligned_rgb = aligned_rgb  # type: ignore
+            main_window.state.aligned = aligned_gray  # type: ignore
+            main_window.state.aligned_rgb = aligned_rgb  # type: ignore
 
             new_processed: List[Optional[np.ndarray]] = [img.copy() for img in aligned_gray]
-            main_window.processed = new_processed  # type: ignore
+            main_window.state.processed = new_processed  # type: ignore
 
             for i in range(3):
                 adjust_channel(main_window, i)
@@ -110,7 +113,7 @@ def load_channel(main_window: "MainWindow", channel_idx: int) -> None:
     rgb_image, file_path, err_msg = load_raw_image(main_window)
 
     if rgb_image is not None and file_path is not None:
-        main_window.channel_paths[channel_idx] = file_path
+        main_window.state.channel_paths[channel_idx] = file_path
         _process_channel_image(main_window, channel_idx, rgb_image)
     else:
         if err_msg != "No file selected":
@@ -131,7 +134,7 @@ def load_channel_from_path(main_window: "MainWindow", channel_idx: int, file_pat
     """
     rgb_image, err_msg = load_raw_image_from_path(file_path)
     if rgb_image is not None:
-        main_window.channel_paths[channel_idx] = file_path
+        main_window.state.channel_paths[channel_idx] = file_path
         _process_channel_image(main_window, channel_idx, rgb_image)
     elif err_msg:
         main_window.status_handler.set_message(
@@ -156,16 +159,16 @@ def adjust_channel(main_window: "MainWindow", channel_idx: int) -> None:
         - update_channel_preview
         - update_main_display
     """
-    if main_window.aligned[channel_idx] is not None:
+    if main_window.state.aligned[channel_idx] is not None:
         main_window.status_handler.set_message("Processing image, please wait...")
         brightness: int = main_window.controllers[channel_idx].sliders["brightness"].value()
         contrast: int = main_window.controllers[channel_idx].sliders["contrast"].value()
-        result = apply_adjustments(main_window.aligned[channel_idx], brightness, contrast)
+        result = apply_adjustments(main_window.state.aligned[channel_idx], brightness, contrast)
         if result is not None:
             # Create a new list to avoid assignment issues
-            processed: List[Optional[np.ndarray]] = list(main_window.processed)
+            processed: List[Optional[np.ndarray]] = list(main_window.state.processed)
             processed[channel_idx] = result
-            main_window.processed = processed  # type: ignore
+            main_window.state.processed = processed  # type: ignore
 
             update_channel_preview(main_window, channel_idx)
             update_main_display(main_window)
@@ -187,7 +190,7 @@ def update_channel_preview(main_window: "MainWindow", channel_idx: int) -> None:
         - ChannelController.update_preview
     """
     controller = main_window.controllers[channel_idx]
-    controller.processed_image = main_window.processed[channel_idx]
+    controller.processed_image = main_window.state.processed[channel_idx]  # type: ignore[assignment]
     controller.update_preview()
 
 
@@ -209,6 +212,6 @@ def show_single_channel(main_window: "MainWindow", channel_idx: int) -> None:
     Cross-references:
         - update_main_display
     """
-    main_window.show_combined = False
-    main_window.current_channel = channel_idx
+    main_window.state.show_combined = False
+    main_window.state.current_channel = channel_idx
     update_main_display(main_window)

--- a/src/handlers/display.py
+++ b/src/handlers/display.py
@@ -43,7 +43,7 @@ def update_main_display(main_window: "MainWindow") -> None:
     Returns:
         None
     """
-    if main_window.show_combined:
+    if main_window.state.show_combined:
         show_combined_image(main_window)
     else:
         show_single_channel_image(main_window)
@@ -64,14 +64,14 @@ def show_combined_image(main_window: "MainWindow") -> None:
     Returns:
         None
     """
-    if any(img is None for img in main_window.processed):
+    if any(img is None for img in main_window.state.processed):
         return
 
     # If not in crop mode and a crop rectangle is set, crop the processed images on-the-fly
     saved_crop_rect = main_window.viewer.get_saved_crop_rect()
-    if not main_window.crop_mode and saved_crop_rect is not None:
+    if not main_window.state.crop_mode and saved_crop_rect is not None:
         cropped_channels: List[np.ndarray | None] = []
-        for img in main_window.processed:
+        for img in main_window.state.processed:
             if img is not None:
                 cropped = img[
                     saved_crop_rect.top() : saved_crop_rect.bottom() + 1,
@@ -88,7 +88,7 @@ def show_combined_image(main_window: "MainWindow") -> None:
 
     # Otherwise use full images
     channels: List[np.ndarray | None] = []
-    for img in main_window.processed:
+    for img in main_window.state.processed:
         if img is not None:
             channels.append(img.copy())
         else:
@@ -112,11 +112,11 @@ def show_single_channel_image(main_window: "MainWindow") -> None:
     Returns:
         None
     """
-    img = main_window.processed[main_window.current_channel]
+    img = main_window.state.processed[main_window.state.current_channel]
     if img is not None:
         # If not in crop mode and a crop rectangle is set, crop the processed image on-the-fly
         saved_crop_rect = main_window.viewer.get_saved_crop_rect()
-        if not main_window.crop_mode and saved_crop_rect is not None:
+        if not main_window.state.crop_mode and saved_crop_rect is not None:
             img = img[
                 saved_crop_rect.top() : saved_crop_rect.bottom() + 1,
                 saved_crop_rect.left() : saved_crop_rect.right() + 1,

--- a/src/handlers/image_saving.py
+++ b/src/handlers/image_saving.py
@@ -215,7 +215,7 @@ def save_image_with_dialog(main_window: "MainWindow") -> Tuple[bool, str]:
             - String with status message
     """
     # Check if there are any images to save
-    if not hasattr(main_window, "aligned") or not any(img is not None for img in main_window.aligned):
+    if not any(img is not None for img in main_window.state.aligned):
         return False, "No images to save"
 
     # Create file format options
@@ -237,11 +237,13 @@ def save_image_with_dialog(main_window: "MainWindow") -> Tuple[bool, str]:
     channel_names = ["ir", "vis", "uv"]
 
     # Save RGB channel images if available
-    if hasattr(main_window, "aligned_rgb") and any(img is not None for img in main_window.aligned_rgb):
-        results.extend(_save_cropped_images(main_window.aligned_rgb, filepath, channel_names, crop_rect, file_format))
+    if any(img is not None for img in main_window.state.aligned_rgb):
+        results.extend(
+            _save_cropped_images(main_window.state.aligned_rgb, filepath, channel_names, crop_rect, file_format)
+        )
 
     # Create and save combined image from grayscale channels
-    combined = _create_combined_image(main_window.aligned, crop_rect)
+    combined = _create_combined_image(main_window.state.aligned, crop_rect)
 
     if combined is not None:
         success, message = save_image(combined, filepath, file_format, is_bgr=False)

--- a/src/handlers/keyboard.py
+++ b/src/handlers/keyboard.py
@@ -57,28 +57,28 @@ def handle_key_press(main_window: "MainWindow", event: QKeyEvent) -> bool:
         - main_window.MainWindow
     """
     if event.key() == Qt.Key.Key_1:
-        main_window.show_combined = False
-        main_window.current_channel = 0
+        main_window.state.show_combined = False
+        main_window.state.current_channel = 0
         main_window.status_handler.set_message("Viewing Red channel", main_window.status_handler.MEDIUM_TIMEOUT)
         update_main_display(main_window)
         event.accept()
         return True
     if event.key() == Qt.Key.Key_2:
-        main_window.show_combined = False
-        main_window.current_channel = 1
+        main_window.state.show_combined = False
+        main_window.state.current_channel = 1
         main_window.status_handler.set_message("Viewing Green channel", main_window.status_handler.MEDIUM_TIMEOUT)
         update_main_display(main_window)
         event.accept()
         return True
     if event.key() == Qt.Key.Key_3:
-        main_window.show_combined = False
-        main_window.current_channel = 2
+        main_window.state.show_combined = False
+        main_window.state.current_channel = 2
         main_window.status_handler.set_message("Viewing Blue channel", main_window.status_handler.MEDIUM_TIMEOUT)
         update_main_display(main_window)
         event.accept()
         return True
     if event.key() == Qt.Key.Key_A:
-        main_window.show_combined = True
+        main_window.state.show_combined = True
         main_window.status_handler.set_message(
             "Viewing combined RGB channel", main_window.status_handler.MEDIUM_TIMEOUT
         )

--- a/src/main_window.py
+++ b/src/main_window.py
@@ -38,7 +38,7 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
-from .default_state import DefaultState
+from .app_state import AppState
 from .handlers.autosave import clear_autosave, restore_autosave, save_autosave
 from .handlers.channels import adjust_channel, load_channel, show_single_channel, update_channel_preview
 from .handlers.display import show_combined_image, show_single_channel_image, update_main_display
@@ -111,28 +111,7 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
         self.setWindowTitle("Prokudin")
         self.setGeometry(100, 100, 1200, 800)
 
-        # State: original, aligned, and processed images for R, G, B channels
-        self.original_images = [None, None, None]
-        self.aligned = [None, None, None]
-        self.processed = [None, None, None]
-        # Add original RGB images storage
-        self.original_rgb_images = [None, None, None]
-        self.aligned_rgb = [None, None, None]
-
-        # File paths for loaded channels (used for autosave/restore)
-        self.channel_paths: list[str | None] = [None, None, None]
-
-        # Display state - use defaults from DefaultState
-        self.show_combined = DefaultState.SHOW_COMBINED
-        self.current_channel = DefaultState.CURRENT_CHANNEL
-
-        # Crop-related state - use defaults from DefaultState
-        self.crop_mode = DefaultState.CROP_MODE
-        self.crop_rect: Union[QRect, None] = None
-        self.crop_ratio: Union[tuple[int, int], None] = None
-
-        # Grid settings dialog (initially None, created on demand)
-        self.grid_settings_dialog: Union[GridSettingsDialog, None] = None
+        self.state = AppState()
 
         self.presets_dir, self.config_dir = self._resolve_dirs()
 
@@ -376,8 +355,8 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
         Returns:
             None
         """
-        loaded_channels = sum(1 for img in self.original_images if img is not None)
-        self.status_handler.update_mode_from_state(loaded_channels, self.crop_mode)
+        loaded_channels = sum(1 for img in self.state.original_images if img is not None)
+        self.status_handler.update_mode_from_state(loaded_channels, self.state.crop_mode)
 
     def toggle_crop_mode(self) -> None:
         """
@@ -397,33 +376,33 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
             - ImageViewer.set_crop_mode
             - update_main_display
         """
-        if self.crop_mode:
+        if self.state.crop_mode:
             return
-        if not any(img is not None for img in self.processed):
+        if not any(img is not None for img in self.state.processed):
             return  # Add error message in UI
-        self.crop_mode = True
+        self.state.crop_mode = True
         self.crop_mode_btn.setVisible(False)
         self.crop_controls_widget.setVisible(True)
         # Use last saved crop rectangle if available
         saved_crop_rect = self.viewer.get_saved_crop_rect() if self.viewer else None
         if saved_crop_rect:
-            self.crop_rect = QRect(saved_crop_rect)
+            self.state.crop_rect = QRect(saved_crop_rect)
         else:
-            if any(img is not None for img in self.processed):
-                for img in self.processed:
+            if any(img is not None for img in self.state.processed):
+                for img in self.state.processed:
                     if img is not None:
                         img_w, img_h = img.shape[1], img.shape[0]
                         rect_w = int(img_w * 0.8)
                         rect_h = int(img_h * 0.8)
                         x = (img_w - rect_w) // 2
                         y = (img_h - rect_h) // 2
-                        self.crop_rect = QRect(x, y, rect_w, rect_h)
+                        self.state.crop_rect = QRect(x, y, rect_w, rect_h)
                         break
-                if self.crop_ratio and self.crop_rect is not None:
-                    self.crop_rect = self._get_aspect_crop_rect(self.crop_rect, self.crop_ratio)
-        self.viewer.set_crop_mode(self.crop_mode)
-        if self.crop_rect:
-            self.viewer.set_crop_rect(self.crop_rect)
+                if self.state.crop_ratio and self.state.crop_rect is not None:
+                    self.state.crop_rect = self._get_aspect_crop_rect(self.state.crop_rect, self.state.crop_ratio)
+        self.viewer.set_crop_mode(self.state.crop_mode)
+        if self.state.crop_rect:
+            self.viewer.set_crop_rect(self.state.crop_rect)
         update_main_display(self)
 
         # Update mode indicator and status message
@@ -447,15 +426,15 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
             - ImageViewer.set_crop_mode
             - update_main_display
         """
-        self.crop_mode = False
+        self.state.crop_mode = False
         self.crop_mode_btn.setVisible(True)
         self.crop_controls_widget.setVisible(False)
         saved_crop_rect = self.viewer.get_saved_crop_rect() if self.viewer else None
         if saved_crop_rect:
-            self.crop_rect = QRect(saved_crop_rect)
-            self.viewer.set_crop_rect(self.crop_rect)
+            self.state.crop_rect = QRect(saved_crop_rect)
+            self.viewer.set_crop_rect(self.state.crop_rect)
         else:
-            self.crop_rect = None
+            self.state.crop_rect = None
         self.viewer.set_crop_mode(False)
         update_main_display(self)
 
@@ -481,20 +460,20 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
             - ImageViewer.set_crop_ratio
             - update_main_display
         """
-        self.crop_ratio = self.crop_ratio_combo.currentData()
+        self.state.crop_ratio = self.crop_ratio_combo.currentData()
         # Always get the current rectangle from the viewer
-        current_rect = self.viewer.get_crop_rect() if self.viewer else self.crop_rect
-        if current_rect and self.crop_ratio:
-            new_rect = self._get_aspect_crop_rect(current_rect, self.crop_ratio)
-            self.crop_rect = new_rect
-            self.viewer.set_crop_ratio(self.crop_ratio)
+        current_rect = self.viewer.get_crop_rect() if self.viewer else self.state.crop_rect
+        if current_rect and self.state.crop_ratio:
+            new_rect = self._get_aspect_crop_rect(current_rect, self.state.crop_ratio)
+            self.state.crop_rect = new_rect
+            self.viewer.set_crop_ratio(self.state.crop_ratio)
             self.viewer.set_crop_rect(new_rect)
-            # Keep viewer._crop_rect and self.crop_rect in sync
+            # Keep viewer._crop_rect and self.state.crop_rect in sync
         elif current_rect:
             # Free mode
             self.viewer.set_crop_ratio(None)
             self.viewer.set_crop_rect(current_rect)
-            self.crop_rect = current_rect
+            self.state.crop_rect = current_rect
         update_main_display(self)
 
     def _get_aspect_crop_rect(self, rect: QRect, ratio: tuple[int, int]) -> QRect:
@@ -548,8 +527,8 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
             - ImageViewer._crop_rect, _saved_crop_rect
             - update_main_display
         """
-        crop_rect = self.viewer.get_crop_rect() if self.viewer else self.crop_rect
-        if not crop_rect or not any(img is not None for img in self.processed):
+        crop_rect = self.viewer.get_crop_rect() if self.viewer else self.state.crop_rect
+        if not crop_rect or not any(img is not None for img in self.state.processed):
             return
 
         crop_rect = self.viewer.get_crop_rect()
@@ -559,8 +538,8 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
 
         # Make sure rectangle is valid and within bounds
         for i in range(3):
-            if self.processed[i] is not None:
-                img = self.processed[i]
+            if self.state.processed[i] is not None:
+                img = self.state.processed[i]
                 if img is not None:  # Double-check to satisfy type checker
                     img_height, img_width = img.shape[:2]
                     valid_rect = QRect(0, 0, img_width, img_height).intersected(saved_rect)
@@ -582,7 +561,7 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
             update_channel_preview(self, i)
 
         # Reset crop mode and UI
-        self.crop_mode = False
+        self.state.crop_mode = False
         self.crop_mode_btn.setVisible(True)
         self.crop_controls_widget.setVisible(False)
         self.viewer.set_crop_mode(False)
@@ -595,7 +574,7 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
         self.status_handler.set_message("Crop applied successfully", self.status_handler.MEDIUM_TIMEOUT)
 
         # Force a full display update
-        if self.show_combined:
+        if self.state.show_combined:
             show_combined_image(self)
         else:
             show_single_channel_image(self)
@@ -643,28 +622,14 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
         Returns:
             None
         """
-        # Clear all image data
-        self.original_images = [None, None, None]
-        self.aligned = [None, None, None]
-        self.processed = [None, None, None]
-        self.original_rgb_images = [None, None, None]
-        self.aligned_rgb = [None, None, None]
-        self.channel_paths = [None, None, None]
-
-        # Reset display state to defaults
-        self.show_combined = DefaultState.SHOW_COMBINED
-        self.current_channel = DefaultState.CURRENT_CHANNEL
-
-        # Reset crop state - exit crop mode if active
-        if self.crop_mode:
-            self.crop_mode = False
+        # Handle UI cleanup before state reset (crop mode needs UI update first)
+        if self.state.crop_mode:
             self.crop_mode_btn.setVisible(True)
             self.crop_controls_widget.setVisible(False)
             self.viewer.set_crop_mode(False)
 
-        # Clear crop geometry
-        self.crop_rect = None
-        self.crop_ratio = None
+        # Reset all mutable state to defaults
+        self.state.reset()
 
         # Clear saved crop from viewer
         if self.viewer:
@@ -698,7 +663,7 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
         Returns:
             None
         """
-        if self.grid_settings_dialog is None:
+        if self.state.grid_settings_dialog is None:
             # Create dialog with current settings
             current_width = self.viewer.grid_overlay.get_line_width()
 
@@ -708,13 +673,13 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
             else:
                 current_type = GRID_TYPE_NONE
 
-            self.grid_settings_dialog = GridSettingsDialog(
+            self.state.grid_settings_dialog = GridSettingsDialog(
                 current_width=current_width, current_grid_type=current_type, parent=self
             )
 
             # Connect signals
-            self.grid_settings_dialog.grid_type_changed.connect(self.on_grid_type_changed)
-            self.grid_settings_dialog.line_width_changed.connect(self.on_grid_line_width_changed)
+            self.state.grid_settings_dialog.grid_type_changed.connect(self.on_grid_type_changed)
+            self.state.grid_settings_dialog.line_width_changed.connect(self.on_grid_line_width_changed)
 
         # Position the dialog near the Grid button with screen boundary checks
         # Get the top-left corner of the button in global coordinates
@@ -728,8 +693,8 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
             # Fallback if screen is not available
             screen_geometry = QApplication.desktop().availableGeometry()  # type: ignore[union-attr]
 
-        dialog_width = self.grid_settings_dialog.width()
-        dialog_height = self.grid_settings_dialog.height()
+        dialog_width = self.state.grid_settings_dialog.width()
+        dialog_height = self.state.grid_settings_dialog.height()
 
         # Default position: to the right and above the button
         dialog_x = button_pos.x() + self.grid_btn.width() + 10  # To the right of button
@@ -751,11 +716,11 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
         if dialog_y + dialog_height > screen_geometry.bottom():
             dialog_y = screen_geometry.bottom() - dialog_height - 10
 
-        self.grid_settings_dialog.move(dialog_x, dialog_y)
+        self.state.grid_settings_dialog.move(dialog_x, dialog_y)
 
         # Show the dialog
-        self.grid_settings_dialog.show()
-        self.grid_settings_dialog.raise_()
+        self.state.grid_settings_dialog.show()
+        self.state.grid_settings_dialog.raise_()
 
     def on_grid_type_changed(self, grid_type: str) -> None:
         """
@@ -823,11 +788,11 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
             None
         """
         # Enable save button if at least one channel image is available
-        has_images = any(img is not None for img in self.aligned)
+        has_images = any(img is not None for img in self.state.aligned)
         self.save_btn.setEnabled(has_images)
 
         # Enable crop button if at least one processed image is available
-        has_processed = any(img is not None for img in self.processed)
+        has_processed = any(img is not None for img in self.state.processed)
         self.crop_mode_btn.setEnabled(has_processed)
 
         # Update mode indicator based on loaded channels
@@ -845,7 +810,7 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
         """
         if event is None:
             return
-        if any(img is not None for img in self.original_images):
+        if any(img is not None for img in self.state.original_images):
             reply = QMessageBox.question(
                 self,
                 "Save Session",
@@ -881,7 +846,7 @@ class MainWindow(QMainWindow):  # pylint: disable=too-many-instance-attributes
         """
         if event is None:
             return
-        if self.crop_mode:
+        if self.state.crop_mode:
             if event.key() == Qt.Key.Key_Escape:
                 self.cancel_crop()
             elif event.key() == Qt.Key.Key_Return or event.key() == Qt.Key.Key_Enter:


### PR DESCRIPTION
# Pull Request

**What does this change do?**
Centralises all mutable session state (images, display flags, crop geometry, grid dialog) in a new AppState dataclass with a reset() method, removing the scattered per-attribute assignments from MainWindow.__init__ and reset_to_defaults().  All handlers and the new autosave module access state through main_window.state.*.

**Checklist:**
- [x] Targets `main` branch
- [x] I have tested my changes
- [x] I have verified against Python 3.8+
- [x] I have updated documentation (if relevant)
- [ ] I have added or updated tests (if relevant)
