### PR TITLE
Add CI and local runner support for Qt widget tests

### DIFF
--- a/.github/workflows/qt-tests.yml
+++ b/.github/workflows/qt-tests.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install -r requirements-test.txt
-          pip install 'PyQt5==5.15.10'  # Pinned version; also in requirements-dev.txt for local dev
+          pip install 'pytest-qt>=4.4.0' 'PyQt5==5.15.10'
 
       - name: Run Qt tests with coverage
         env:

--- a/.github/workflows/qt-tests.yml
+++ b/.github/workflows/qt-tests.yml
@@ -1,4 +1,4 @@
-name: Widget Tests with Coverage
+name: Qt Tests with Coverage
 
 on:
   push:
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 jobs:
-  widget-tests:
+  qt-tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -34,15 +34,15 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-test.txt
 
-      - name: Run widget tests with coverage
+      - name: Run Qt tests with coverage
         env:
           QT_QPA_PLATFORM: offscreen
         run: |
-          pytest tests/qt/ --cov=src.ui --cov-branch --cov-report=term-missing --cov-report=html:htmlcov-widget
+          pytest tests/qt/ --cov=src.ui --cov-branch --cov-report=term-missing --cov-report=html:htmlcov-qt
 
       - name: Upload coverage HTML report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: widget-coverage-html
-          path: htmlcov-widget
+          name: qt-coverage-html
+          path: htmlcov-qt

--- a/.github/workflows/qt-tests.yml
+++ b/.github/workflows/qt-tests.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install -r requirements-test.txt
+          pip install 'PyQt5==5.15.10'  # Pinned version; also in requirements-dev.txt for local dev
 
       - name: Run Qt tests with coverage
         env:

--- a/.github/workflows/widget-tests.yml
+++ b/.github/workflows/widget-tests.yml
@@ -1,4 +1,4 @@
-name: Unit Tests with Coverage
+name: Widget Tests with Coverage
 
 on:
   push:
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 jobs:
-  unit-tests:
+  widget-tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -26,18 +26,23 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Install dependencies
+      - name: Install system Qt dependencies
+        run: sudo apt-get install -y libxkbcommon-x11-0 libgl1
+
+      - name: Install Python dependencies
         run: |
           pip install -r requirements.txt
-          if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
+          pip install -r requirements-test.txt
 
-      - name: Run unit tests with coverage
+      - name: Run widget tests with coverage
+        env:
+          QT_QPA_PLATFORM: offscreen
         run: |
-          pytest tests/unit/ --cov=src --cov-branch --cov-report=term-missing --cov-report=html:htmlcov
+          pytest tests/qt/ --cov=src.ui --cov-branch --cov-report=term-missing --cov-report=html:htmlcov-widget
 
       - name: Upload coverage HTML report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-html
-          path: htmlcov
+          name: widget-coverage-html
+          path: htmlcov-widget

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,9 +3,6 @@ pytest==8.3.0
 pytest-cov==6.0.0
 coverage[toml]==7.5.0
 
-# Qt testing (PyQt5 provided by requirements-dev.txt for local dev, or by system in CI)
-pytest-qt>=4.4.0
-
 # Test documentation
 interrogate==1.5.0
 setuptools==69.1.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,12 +3,9 @@ pytest==8.3.0
 pytest-cov==6.0.0
 coverage[toml]==7.5.0
 
-# Widget testing (requires QApplication / offscreen platform)
+# Qt testing (PyQt5 provided by requirements-dev.txt for local dev, or by system in CI)
 pytest-qt>=4.4.0
-PyQt5==5.15.10
 
 # Test documentation
 interrogate==1.5.0
 setuptools==69.1.0
-
-

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,6 +5,7 @@ coverage[toml]==7.5.0
 
 # Widget testing (requires QApplication / offscreen platform)
 pytest-qt>=4.4.0
+PyQt5==5.15.10
 
 # Test documentation
 interrogate==1.5.0

--- a/run_tests.py
+++ b/run_tests.py
@@ -60,7 +60,7 @@ def install_dependencies(*, qt: bool = False) -> None:
     """Install test and production dependencies if they've changed or are missing.
 
     Args:
-        qt: If True, also install PyQt5 for Qt testing (from requirements-dev.txt version).
+        qt: If True, also install pytest-qt and PyQt5 for Qt testing.
     """
     if not requirements_changed():
         return
@@ -75,9 +75,9 @@ def install_dependencies(*, qt: bool = False) -> None:
         cwd=Path.cwd(),
     )
     if qt:
-        print("Installing PyQt5 for Qt testing...")
+        print("Installing pytest-qt and PyQt5 for Qt testing...")
         subprocess.check_call(
-            [str(PYTHON_EXE), "-m", "pip", "install", "-q", "PyQt5==5.15.10"],
+            [str(PYTHON_EXE), "-m", "pip", "install", "-q", "pytest-qt>=4.4.0", "PyQt5==5.15.10"],
             cwd=Path.cwd(),
         )
     VENV_MARKER.write_text(get_requirements_hash())

--- a/run_tests.py
+++ b/run_tests.py
@@ -56,8 +56,12 @@ def create_venv() -> None:
         venv.create(VENV_DIR, with_pip=True)
 
 
-def install_dependencies() -> None:
-    """Install test and production dependencies if they've changed or are missing."""
+def install_dependencies(*, qt: bool = False) -> None:
+    """Install test and production dependencies if they've changed or are missing.
+
+    Args:
+        qt: If True, also install PyQt5 for Qt testing (from requirements-dev.txt version).
+    """
     if not requirements_changed():
         return
 
@@ -70,6 +74,12 @@ def install_dependencies() -> None:
         [str(PYTHON_EXE), "-m", "pip", "install", "-q", "-r", "requirements-test.txt"],
         cwd=Path.cwd(),
     )
+    if qt:
+        print("Installing PyQt5 for Qt testing...")
+        subprocess.check_call(
+            [str(PYTHON_EXE), "-m", "pip", "install", "-q", "PyQt5==5.15.10"],
+            cwd=Path.cwd(),
+        )
     VENV_MARKER.write_text(get_requirements_hash())
 
 
@@ -373,7 +383,7 @@ Examples:
 
     try:
         create_venv()
-        install_dependencies()
+        install_dependencies(qt=args.qt)
 
         if args.pytest_only:
             cmd = [str(PYTHON_EXE), "-m", "pytest"]

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
-"""Cross-platform script to run unit tests with automatic venv management.
+"""Cross-platform script to run unit and widget tests with automatic venv management.
 
 Usage:
-    python3 run_tests.py                    # Run with summary output
+    python3 run_tests.py                    # Run unit tests with summary output
     python3 run_tests.py -v, --verbose      # Show detailed coverage report
     python3 run_tests.py -m core.align      # Run tests for specific module
     python3 run_tests.py -m handlers.channels -v  # Module tests with verbose output
     python3 run_tests.py --pytest-only      # Run pytest only (no coverage/docs checks)
     python3 run_tests.py --pytest-only -k "test_align"  # Pytest only with filter
+    python3 run_tests.py --widget           # Run Qt widget tests (QT_QPA_PLATFORM=offscreen set automatically)
+    python3 run_tests.py --widget -v        # Widget tests with detailed coverage report
+    python3 run_tests.py --widget --pytest-only  # Widget pytest only (visible output)
 """
 
 import argparse
@@ -220,12 +223,13 @@ def run_tests(*, module: str | None = None, verbose: bool = False, args: list[st
         return 1
 
 
-def check_test_docs(module: str | None = None, verbose: bool = False) -> int:
+def check_test_docs(module: str | None = None, verbose: bool = False, test_dir: str = "tests") -> int:
     """Check that all tests are documented.
 
     Args:
         module: Specific module to check, or None for all
         verbose: Show detailed documentation report
+        test_dir: Directory to check (default "tests"; use "tests/qt" for widget tests)
 
     Documentation coverage is always enforced at 100% for test files.
     """
@@ -233,8 +237,8 @@ def check_test_docs(module: str | None = None, verbose: bool = False) -> int:
         # Check specific module's test file
         target = f"tests/unit/test_{module.replace('.', '_')}.py"
     else:
-        # Check all test files
-        target = "tests"
+        # Check all test files in the given directory
+        target = test_dir
 
     print(f"\n{'=' * 60}")
     print("Checking test documentation...")
@@ -271,19 +275,75 @@ def check_test_docs(module: str | None = None, verbose: bool = False) -> int:
         return 1
 
 
+def run_widget_tests(*, verbose: bool = False, args: list[str] | None = None) -> int:
+    """Run Qt widget tests from tests/qt/ with coverage.
+
+    Sets QT_QPA_PLATFORM=offscreen automatically. Coverage is measured across
+    all of src/ui so progress is visible as widget tests are added.
+
+    Args:
+        verbose: Show full pytest output and coverage report
+        args: Additional pytest arguments
+    """
+    args = args or []
+
+    cmd = [
+        str(PYTHON_EXE),
+        "-m",
+        "pytest",
+        "tests/qt/",
+        "--cov=src.ui",
+        "--cov-branch",
+        "--cov-report=term-missing",
+        "--cov-report=html:htmlcov-widget",
+    ]
+    cmd.extend(args)
+
+    print(f"\n{'=' * 60}")
+    print("Running widget tests (QT_QPA_PLATFORM=offscreen)...")
+    print("=" * 60)
+
+    env = {**os.environ, "QT_QPA_PLATFORM": "offscreen"}
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, env=env)
+
+        if verbose:
+            print(result.stdout)
+            if result.stderr:
+                print(result.stderr)
+        else:
+            test_summary = extract_test_summary(result.stdout)
+            coverage_pct = extract_coverage_summary(result.stdout)
+            print(test_summary)
+            if coverage_pct[0] != "N/A":
+                print(f"Code Coverage: {coverage_pct[0]}%")
+
+        if result.returncode != 0 and not verbose:
+            print("\n⚠️  Tests failed. Run with -v/--verbose for details.")
+
+        return result.returncode
+    except subprocess.CalledProcessError as e:
+        print(f"Error running widget tests: {e}")
+        return 1
+
+
 def main() -> None:
     """Main entry point."""
     parser = argparse.ArgumentParser(
-        description="Run unit tests with coverage and documentation checks",
+        description="Run unit or widget tests with coverage and documentation checks",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  %(prog)s                          Run all tests with summary output
+  %(prog)s                          Run all unit tests with summary output
   %(prog)s -v                       Run with detailed coverage report
   %(prog)s -m core.align            Run tests for align module only
   %(prog)s -m handlers.channels -v  Run module tests with verbose output
   %(prog)s --pytest-only            Run pytest directly (visible output, no checks)
   %(prog)s --pytest-only -k "test_align"  Pytest only, filtered by keyword
+  %(prog)s --widget                 Run Qt widget tests (offscreen, no display needed)
+  %(prog)s --widget -v              Widget tests with detailed coverage report
+  %(prog)s --widget --pytest-only   Widget pytest with visible output, no checks
         """,
     )
     parser.add_argument(
@@ -303,6 +363,11 @@ Examples:
         type=str,
         help="Run tests for specific module (e.g., core.align, handlers.channels)",
     )
+    parser.add_argument(
+        "--widget",
+        action="store_true",
+        help="Run Qt widget tests from tests/qt/ (QT_QPA_PLATFORM=offscreen set automatically)",
+    )
 
     args, pytest_args = parser.parse_known_args()
 
@@ -312,18 +377,26 @@ Examples:
 
         if args.pytest_only:
             cmd = [str(PYTHON_EXE), "-m", "pytest"]
-            if args.module:
-                cmd.append(f"tests/unit/test_{args.module.replace('.', '_')}.py")
-            cmd.extend(pytest_args)
-            result = subprocess.run(cmd)
+            if args.widget:
+                cmd.append("tests/qt/")
+                env = {**os.environ, "QT_QPA_PLATFORM": "offscreen"}
+                result = subprocess.run(cmd + pytest_args, env=env)
+            else:
+                if args.module:
+                    cmd.append(f"tests/unit/test_{args.module.replace('.', '_')}.py")
+                result = subprocess.run(cmd + pytest_args)
             sys.exit(result.returncode)
 
         print("\n" + "=" * 60)
         print("TEST COVERAGE REPORT")
         print("=" * 60)
 
-        test_result = run_tests(module=args.module, verbose=args.verbose, args=pytest_args)
-        doc_result = check_test_docs(module=args.module, verbose=args.verbose)
+        if args.widget:
+            test_result = run_widget_tests(verbose=args.verbose, args=pytest_args)
+            doc_result = check_test_docs(verbose=args.verbose, test_dir="tests/qt")
+        else:
+            test_result = run_tests(module=args.module, verbose=args.verbose, args=pytest_args)
+            doc_result = check_test_docs(module=args.module, verbose=args.verbose)
 
         print("\n" + "=" * 60)
         print("SUMMARY")

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Cross-platform script to run unit and widget tests with automatic venv management.
+"""Cross-platform script to run unit and Qt tests with automatic venv management.
 
 Usage:
     python3 run_tests.py                    # Run unit tests with summary output
@@ -8,9 +8,9 @@ Usage:
     python3 run_tests.py -m handlers.channels -v  # Module tests with verbose output
     python3 run_tests.py --pytest-only      # Run pytest only (no coverage/docs checks)
     python3 run_tests.py --pytest-only -k "test_align"  # Pytest only with filter
-    python3 run_tests.py --widget           # Run Qt widget tests (QT_QPA_PLATFORM=offscreen set automatically)
-    python3 run_tests.py --widget -v        # Widget tests with detailed coverage report
-    python3 run_tests.py --widget --pytest-only  # Widget pytest only (visible output)
+    python3 run_tests.py --qt           # Run Qt tests (QT_QPA_PLATFORM=offscreen set automatically)
+    python3 run_tests.py --qt -v        # Qt tests with detailed coverage report
+    python3 run_tests.py --qt --pytest-only  # Qt pytest only (visible output)
 """
 
 import argparse
@@ -229,7 +229,7 @@ def check_test_docs(module: str | None = None, verbose: bool = False, test_dir: 
     Args:
         module: Specific module to check, or None for all
         verbose: Show detailed documentation report
-        test_dir: Directory to check (default "tests"; use "tests/qt" for widget tests)
+        test_dir: Directory to check (default "tests"; use "tests/qt" for Qt tests)
 
     Documentation coverage is always enforced at 100% for test files.
     """
@@ -275,11 +275,11 @@ def check_test_docs(module: str | None = None, verbose: bool = False, test_dir: 
         return 1
 
 
-def run_widget_tests(*, verbose: bool = False, args: list[str] | None = None) -> int:
-    """Run Qt widget tests from tests/qt/ with coverage.
+def run_qt_tests(*, verbose: bool = False, args: list[str] | None = None) -> int:
+    """Run Qt tests from tests/qt/ with coverage.
 
     Sets QT_QPA_PLATFORM=offscreen automatically. Coverage is measured across
-    all of src/ui so progress is visible as widget tests are added.
+    all of src/ui so progress is visible as Qt tests are added.
 
     Args:
         verbose: Show full pytest output and coverage report
@@ -295,12 +295,12 @@ def run_widget_tests(*, verbose: bool = False, args: list[str] | None = None) ->
         "--cov=src.ui",
         "--cov-branch",
         "--cov-report=term-missing",
-        "--cov-report=html:htmlcov-widget",
+        "--cov-report=html:htmlcov-qt",
     ]
     cmd.extend(args)
 
     print(f"\n{'=' * 60}")
-    print("Running widget tests (QT_QPA_PLATFORM=offscreen)...")
+    print("Running Qt tests (QT_QPA_PLATFORM=offscreen)...")
     print("=" * 60)
 
     env = {**os.environ, "QT_QPA_PLATFORM": "offscreen"}
@@ -324,14 +324,14 @@ def run_widget_tests(*, verbose: bool = False, args: list[str] | None = None) ->
 
         return result.returncode
     except subprocess.CalledProcessError as e:
-        print(f"Error running widget tests: {e}")
+        print(f"Error running Qt tests: {e}")
         return 1
 
 
 def main() -> None:
     """Main entry point."""
     parser = argparse.ArgumentParser(
-        description="Run unit or widget tests with coverage and documentation checks",
+        description="Run unit or Qt tests with coverage and documentation checks",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
@@ -341,9 +341,9 @@ Examples:
   %(prog)s -m handlers.channels -v  Run module tests with verbose output
   %(prog)s --pytest-only            Run pytest directly (visible output, no checks)
   %(prog)s --pytest-only -k "test_align"  Pytest only, filtered by keyword
-  %(prog)s --widget                 Run Qt widget tests (offscreen, no display needed)
-  %(prog)s --widget -v              Widget tests with detailed coverage report
-  %(prog)s --widget --pytest-only   Widget pytest with visible output, no checks
+  %(prog)s --qt                 Run Qt tests (offscreen, no display needed)
+  %(prog)s --qt -v              Qt tests with detailed coverage report
+  %(prog)s --qt --pytest-only   Qt pytest with visible output, no checks
         """,
     )
     parser.add_argument(
@@ -364,9 +364,9 @@ Examples:
         help="Run tests for specific module (e.g., core.align, handlers.channels)",
     )
     parser.add_argument(
-        "--widget",
+        "--qt",
         action="store_true",
-        help="Run Qt widget tests from tests/qt/ (QT_QPA_PLATFORM=offscreen set automatically)",
+        help="Run Qt tests from tests/qt/ (QT_QPA_PLATFORM=offscreen set automatically)",
     )
 
     args, pytest_args = parser.parse_known_args()
@@ -377,7 +377,7 @@ Examples:
 
         if args.pytest_only:
             cmd = [str(PYTHON_EXE), "-m", "pytest"]
-            if args.widget:
+            if args.qt:
                 cmd.append("tests/qt/")
                 env = {**os.environ, "QT_QPA_PLATFORM": "offscreen"}
                 result = subprocess.run(cmd + pytest_args, env=env)
@@ -391,8 +391,8 @@ Examples:
         print("TEST COVERAGE REPORT")
         print("=" * 60)
 
-        if args.widget:
-            test_result = run_widget_tests(verbose=args.verbose, args=pytest_args)
+        if args.qt:
+            test_result = run_qt_tests(verbose=args.verbose, args=pytest_args)
             doc_result = check_test_docs(verbose=args.verbose, test_dir="tests/qt")
         else:
             test_result = run_tests(module=args.module, verbose=args.verbose, args=pytest_args)


### PR DESCRIPTION
# Pull Request

**What does this change do?**
- widget-tests.yml: new workflow that installs libxkbcommon-x11-0 and libgl1, sets QT_QPA_PLATFORM=offscreen, runs tests/qt/ with coverage on src.ui, uploads HTML coverage artifact
- unit-tests.yml: explicitly target tests/unit/ so Qt-less CI never tries to collect tests/qt/ without a display
- requirements-test.txt: add PyQt5==5.15.10 and pytest-qt>=4.4.0 so the test venv can run widget tests without the app's Docker image
- run_tests.py: add --widget flag (run_widget_tests, check_test_docs test_dir param) and --widget --pytest-only passthrough

**Checklist:**
- [x] Targets `main` branch
- [x] I have tested my changes
- [x] I have verified against Python 3.8+
- [x] I have updated documentation (if relevant)
- [x] I have added or updated tests (if relevant)