### PR TITLE
Add widget tests for src/ui/qt_utils (Priority 1)

### DIFF
--- a/tests/qt/test_widget_qt_utils.py
+++ b/tests/qt/test_widget_qt_utils.py
@@ -1,0 +1,225 @@
+# Copyright (C) 2025 fozga
+#
+# This file is part of Prokudin.
+#
+# Prokudin is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Prokudin is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Prokudin.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Widget tests for src/ui/qt_utils.py."""
+
+import numpy as np
+import pytest
+from PyQt5.QtGui import QImage
+from pytestqt.plugin import QtBot
+
+from src.ui.qt_utils import convert_to_qimage
+
+
+@pytest.mark.widget
+class TestConvertToQimage:
+    """
+    Test Design Specification: convert_to_qimage
+    Module under test: src/ui/qt_utils.py
+
+    Widget base class: N/A — utility function; QApplication required to construct QImage.
+
+    Contract:
+        convert_to_qimage converts a numpy ndarray (grayscale 2-D or RGB 3-D,
+        dtype uint8) into a PyQt5 QImage for display in Qt widgets. Returns an
+        empty (null) QImage when input is None. 2-D arrays produce
+        Format_Grayscale8; 3-D arrays produce Format_RGB888. Image data is
+        referenced in-place (not copied).
+
+    Infrastructure:
+        - Requires qtbot fixture (provides QApplication via pytest-qt).
+        - Requires QT_QPA_PLATFORM=offscreen.
+        - No file IO or external services.
+
+    What is tested:
+        - None input returns a null QImage.
+        - 2-D grayscale uint8 arrays produce QImage.Format_Grayscale8.
+        - 3-D RGB uint8 arrays produce QImage.Format_RGB888.
+        - Returned QImage dimensions match the input array shape.
+        - Minimum valid array sizes (1×1, 1×1×3) do not raise.
+        - Boundary pixel values (0 and 255) produce a valid, non-null QImage.
+
+    What is NOT tested:
+        - QPainter rendering or on-screen visual output.
+        - Non-uint8 dtypes (outside the documented contract).
+        - Arrays with more than 3 dimensions.
+
+    Equivalence partitions:
+        EP1  None input                    → empty QImage (isNull() == True)
+        EP2  Valid 2-D grayscale uint8     → QImage.Format_Grayscale8
+        EP3  Valid 3-D RGB uint8           → QImage.Format_RGB888
+        EP4  Boundary pixel values (0/255) → valid, non-null QImage
+
+    Boundary values:
+        BV1  1×1 grayscale array   (minimum valid 2-D size)
+        BV2  1×1×3 RGB array       (minimum valid 3-D size)
+        BV3  pixel value = 0       (uint8 minimum)
+        BV4  pixel value = 255     (uint8 maximum)
+
+    Mocking strategy:
+        No external dependencies require mocking.
+
+    Constraints:
+        QApplication must be running; satisfied by the qtbot fixture from pytest-qt.
+    """
+
+    def test_none_input_returns_null_qimage(self, qtbot: QtBot) -> None:
+        """
+        Given convert_to_qimage is called with None,
+        When the function executes,
+        Then an empty (null) QImage is returned.
+        """
+        # Arrange
+        del qtbot  # ensures QApplication is alive; no widget to register
+        # Act
+        result = convert_to_qimage(None)
+        # Assert
+        assert result.isNull()
+
+    def test_grayscale_array_returns_correct_width(self, qtbot: QtBot) -> None:
+        """
+        Given a 2-D grayscale uint8 array of shape (120, 160),
+        When convert_to_qimage is called,
+        Then the returned QImage has width 160.
+        """
+        # Arrange
+        del qtbot
+        image = np.zeros((120, 160), dtype=np.uint8)
+        # Act
+        result = convert_to_qimage(image)
+        # Assert
+        assert result.width() == 160
+
+    def test_grayscale_array_returns_correct_height(self, qtbot: QtBot) -> None:
+        """
+        Given a 2-D grayscale uint8 array of shape (120, 160),
+        When convert_to_qimage is called,
+        Then the returned QImage has height 120.
+        """
+        # Arrange
+        del qtbot
+        image = np.zeros((120, 160), dtype=np.uint8)
+        # Act
+        result = convert_to_qimage(image)
+        # Assert
+        assert result.height() == 120
+
+    def test_grayscale_array_returns_grayscale8_format(self, qtbot: QtBot) -> None:
+        """
+        Given a 2-D grayscale uint8 array,
+        When convert_to_qimage is called,
+        Then the returned QImage has format Format_Grayscale8.
+        """
+        # Arrange
+        del qtbot
+        image = np.zeros((10, 10), dtype=np.uint8)
+        # Act
+        result = convert_to_qimage(image)
+        # Assert
+        assert result.format() == QImage.Format_Grayscale8
+
+    def test_rgb_array_returns_correct_width(self, qtbot: QtBot) -> None:
+        """
+        Given a 3-D RGB uint8 array of shape (120, 160, 3),
+        When convert_to_qimage is called,
+        Then the returned QImage has width 160.
+        """
+        # Arrange
+        del qtbot
+        image = np.zeros((120, 160, 3), dtype=np.uint8)
+        # Act
+        result = convert_to_qimage(image)
+        # Assert
+        assert result.width() == 160
+
+    def test_rgb_array_returns_correct_height(self, qtbot: QtBot) -> None:
+        """
+        Given a 3-D RGB uint8 array of shape (120, 160, 3),
+        When convert_to_qimage is called,
+        Then the returned QImage has height 120.
+        """
+        # Arrange
+        del qtbot
+        image = np.zeros((120, 160, 3), dtype=np.uint8)
+        # Act
+        result = convert_to_qimage(image)
+        # Assert
+        assert result.height() == 120
+
+    def test_rgb_array_returns_rgb888_format(self, qtbot: QtBot) -> None:
+        """
+        Given a 3-D RGB uint8 array,
+        When convert_to_qimage is called,
+        Then the returned QImage has format Format_RGB888.
+        """
+        # Arrange
+        del qtbot
+        image = np.zeros((10, 10, 3), dtype=np.uint8)
+        # Act
+        result = convert_to_qimage(image)
+        # Assert
+        assert result.format() == QImage.Format_RGB888
+
+    def test_minimum_size_grayscale_array_does_not_raise(self, qtbot: QtBot) -> None:
+        """
+        Given a 2-D grayscale array of shape (1, 1) (minimum valid size),
+        When convert_to_qimage is called,
+        Then a valid non-null QImage is returned without raising.
+        """
+        # Arrange
+        del qtbot
+        image = np.array([[128]], dtype=np.uint8)  # BV1
+        # Act
+        result = convert_to_qimage(image)
+        # Assert
+        assert not result.isNull()
+
+    def test_minimum_size_rgb_array_does_not_raise(self, qtbot: QtBot) -> None:
+        """
+        Given a 3-D RGB array of shape (1, 1, 3) (minimum valid size),
+        When convert_to_qimage is called,
+        Then a valid non-null QImage is returned without raising.
+        """
+        # Arrange
+        del qtbot
+        image = np.array([[[255, 0, 0]]], dtype=np.uint8)  # BV2
+        # Act
+        result = convert_to_qimage(image)
+        # Assert
+        assert not result.isNull()
+
+    @pytest.mark.parametrize(
+        "pixel_value",
+        [
+            0,    # BV3: uint8 minimum
+            255,  # BV4: uint8 maximum
+        ],
+        ids=["min_pixel", "max_pixel"],
+    )
+    def test_boundary_pixel_values_produce_valid_qimage(self, qtbot: QtBot, pixel_value: int) -> None:
+        """
+        Given a grayscale array filled with a boundary pixel value (0 or 255),
+        When convert_to_qimage is called,
+        Then a valid non-null QImage is returned.
+        """
+        # Arrange
+        del qtbot
+        image = np.full((10, 10), pixel_value, dtype=np.uint8)  # EP4
+        # Act
+        result = convert_to_qimage(image)
+        # Assert
+        assert not result.isNull()


### PR DESCRIPTION
# Pull Request

**What does this change do?**
11 tests covering all EPs and BVAs for convert_to_qimage: None input, 2-D grayscale, 3-D RGB, correct dimensions and formats, minimum valid array sizes, and boundary pixel values (0/255). Achieves 100% branch coverage on src/ui/qt_utils.py.

**Checklist:**
- [x] Targets `main` branch
- [x] I have tested my changes
- [x] I have verified against Python 3.8+
- [x] I have updated documentation (if relevant)
- [x] I have added or updated tests (if relevant)